### PR TITLE
add support for top-level declarations

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -35,3 +35,4 @@
 ## Ecosystem
 - syntax highligher for VSCode
 - sourcemaps
+- repl

--- a/src/__tests__/eval.test.ts
+++ b/src/__tests__/eval.test.ts
@@ -1,6 +1,18 @@
-// TODO: write some evaluation tests
+import { evaluate, print } from '../eval';
+import { parse } from '../parser'
 
 describe('evaluate', () => {
-  test.todo('((x, y, z) => x + y + z)(1, 2, 3)');
-  test.todo('((x, y, z) => x + y + z)(1)(2)(3)');
+  test.each([
+    ['((x:number, y:number, z:number) => x + y + z)(1, 2, 3)', '6'],
+    // TODO: implement partial application
+    // ['((x:number, y:number, z:number) => x + y + z)(1)(2)(3)', '6'],
+  ])('%s = %s', (source, expected) => {
+    const prog = parse(source + ';');
+    const value = evaluate(prog);
+    if (!value) {
+      throw new Error("program did not return a value");
+    }
+    const actual = print(value);
+    expect(actual).toEqual(expected);
+  })
 });

--- a/src/__tests__/parser.test.ts
+++ b/src/__tests__/parser.test.ts
@@ -48,33 +48,36 @@ describe("parse", () => {
     ["1 + 2 * 3"],
     ["() => 1"],
     ["(() => 1)()"],
-    ["(x) => x + 1"],
-    ["(x) => (y) => x + y"],
-    ["(x) => {let foo = 5; foo}"],
-    ["((x) => (y) => x + y)(1)(2)"],
-    ["(x, y, z) => x + y + z"],
-    ["((x, y, z) => x + y + z)(1, 2, 3)"],
-    [`((x, y, z) => {
+    ["(x:number) => x + 1"],
+    ["(x:number) => (y:number) => x + y"],
+    ["(x:number) => {let foo = 5; foo}"],
+    ["((x:number) => (y:number) => x + y)(1)(2)"],
+    ["(x:number, y:number, z:number) => x + y + z"],
+    ["((x:number, y:number, z:number) => x + y + z)(1, 2, 3)"],
+    [`((x:number, y:number, z:number) => {
       let sum = x + y + z
       sum
     })`],
-    [`((x, y, z) => {
+    [`((x:number, y:number, z:number) => {
       let sum = x + y + z; sum
     })`],
   ])("should parse '%s'", (input) => {
-    expect(input).toParse();
+    expect(input + ';').toParse();
   });
 
   it.each([
     [".", "Unexpected '.' at 1:1"],
-    ["((x, y, z) => let sum = x + y + z; sum)", "Unexpected 'let' at 1:15"],
-    [`((x, y, z) =>
+    [
+      "((x:number, y:number, z:number) => let sum = x + y + z; sum)", 
+      "Unexpected 'let' at 1:36",
+    ],
+    [`((x:number, y:number, z:number) =>
       let sum = x + y + z
       sum
     )`, "Unexpected 'let' at 2:7"],
-    ["(x) => {let let = 5; foo}", "Unexpected 'let' at 1:13"], // keywords can't be identifiers
+    ["(x:number) => {let let = 5; foo}", "Unexpected 'let' at 1:20"], // keywords can't be identifiers
     [`"hello, ""world!"`, "Unexpected '\"world!\"' at 1:10"]
   ])("should not parse '%s'", (input, error) => {
-    expect(() => parse(input)).toThrowError(error)
+    expect(() => parse(input + ';')).toThrowError(error)
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
-import { Stack } from 'immutable'
 import util from 'util'
 
 import { evaluate } from './eval'
@@ -9,28 +8,37 @@ import { check } from './checker';
 
 const options = { showHidden: false, depth: null, colors: true };
 
+const prog = parse(`
+let add = (x:number, y:number) => x + y
+let sub = (x:number, y:number) => x - y
+add(5, 10)
+`);
+console.log(util.inspect(prog, options));
+console.log(`src:\n${print(prog)}\n`);
+check(prog);
+
 const expr1 = parse("(x:number) => (y:number) => x + y");
 console.log(expr1);
 
-const expr2 = parse("((x:number) => (y:number) => (z:number) => x + y + z)(1)(2)(3)");
+const expr2 = parse("((x:number) => (y:number) => (z:number) => x + y + z)(1)(2)(3);");
 console.log(util.inspect(expr2, options));
-check(expr2, {scopes: Stack()});
+check(expr2);
 console.log(evaluate(expr2));
 console.log(printJs(expr2));
 console.log(`js eval'd: ${eval(printJs(expr2))}`);
 
 const expr3 = parse(`
 ((x:number, y:number, z:number) => {
-  let sum = x + y + z
-  sum
-})(1, 2, 3)`);
+  let sum = x + y + z;
+  sum;
+})(1, 2, 3);`);
 console.log(util.inspect(expr3, options));
-check(expr3, {scopes: Stack()});
+check(expr3);
 console.log(evaluate(expr3));
 console.log(`src:\n${print(expr3)}\n`);
 console.log(`js:\n${printJs(expr3)}\n`);
 console.log(`js eval'd: ${eval(printJs(expr3))}`);
 
-const expr4 = parse("(() => 5)()");
+const expr4 = parse("(() => 5)();");
 console.log(util.inspect(expr4, options));
 console.log(evaluate(expr4));

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -2,9 +2,9 @@ import * as nearley from "nearley";
 import type {Token} from "moo";
 
 import {grammar} from "./grammar"
-import type { Expr } from "./syntax";
+import type { Program } from "./syntax";
 
-export const parse = (input: string): Expr => {
+export const parse = (input: string): Program => {
   const parser = new nearley.Parser(grammar);
   try {
     parser.feed(input);

--- a/src/syntax.ts
+++ b/src/syntax.ts
@@ -1,6 +1,7 @@
-export type BinOp = "Add" | "Sub" | "Mul" | "Div";
+export type Program = { tag: "Program", body: (Expr | Decl)[] };
 
-// TODO: add support for let-in
+export type Decl = { tag: "Decl", name: string; value: Expr; };
+
 export type Expr =
   | { tag: "Var"; name: string }
   | { tag: "Lit"; value: Lit }
@@ -18,3 +19,5 @@ export type Lit =
   | { tag: "LArr"; value: Expr[] };
 
 export type Param = { tag: "Param"; name: string; type: string };
+
+export type BinOp = "Add" | "Sub" | "Mul" | "Div";


### PR DESCRIPTION
This introduces a `Program` type which contains multiple declarations/expressions.  Each of these must be finalized by a semi-colon or a newline.

This PR also implements our first eval test.

# Test Plan:
- yarn build && node lib/index.js
- yarn jest