### PR TITLE
Add Literal to the AST and update tests to use it

### DIFF
--- a/docs/type_system.md
+++ b/docs/type_system.md
@@ -64,6 +64,13 @@ doesn't.
 
 TODO: fill this out
 
+### enums
+
+Enums can be either a subtype of strings or a subtype of numbers (depending on
+what values are used to define them).  This means that if there's a function that
+takes a string we can pass and enum to it.  This could be useful in printing out
+enums (or using them from a select dropdown).
+
 ### refs
 
 What about `ref`s?  We can't just pass a `ref<5>` to a function excepting

--- a/hindley-milner/README.md
+++ b/hindley-milner/README.md
@@ -26,3 +26,11 @@ Learning example based on https://github.com/rob-smallshire/hindley-milner-pytho
   - https://gist.github.com/yelouafi/57825fdd223e5337ba0cd2b6ed757f53
   - https://overreacted.io/algebraic-effects-for-the-rest-of-us/
   - https://www.microsoft.com/en-us/research/wp-content/uploads/2016/08/algeff-tr-2016-v3.pdf
+- higher kinded types are like Apply at the type-level, e.g. f a -> f b
+  - class Functor f where 
+    fmap :: (a -> b) -> f a -> f b
+  - `fmap` takes a function and a value wrapped in a functor, unwraps the
+    value, applies the function, and rewraps it for us.
+  - use schemes to represent contraints on higher kinded types
+  - `pure` wraps data in given applicative (in PureScript)
+  - e.g. `pure x = Just x` in the case of the Maybe applicative

--- a/hindley-milner/src/ast.ts
+++ b/hindley-milner/src/ast.ts
@@ -32,6 +32,60 @@ export class Identifier {
     }
 }
 
+export class Int {
+    value: number;
+
+    constructor(value: number) {
+        this.value = value;
+    }
+
+    toString(): string {
+        return this.value.toString();
+    }
+}
+
+export class Bool {
+    value: boolean;
+
+    constructor(value: boolean) {
+        this.value = value;
+    }
+
+    toString(): string {
+        return this.value.toString();
+    }
+}
+
+export class Arr {
+    // The AST allows for array literals to contain a mix of values.
+    // TODO: How will type inference handle a mix of values?
+    // - option 1: determine a type that encompases all types in the mix
+    // - option 2: disallow the mix unless we specify a type for the array
+    //             in the source, then check that this type works given the
+    //             values in the array
+    values: Expression[];
+
+    constructor(values: Expression[]) {
+        this.values = values;
+    }
+
+    toString(): string {
+        return `[${this.values.map(v => v.toString()).join(", ")}]`;
+    }
+}
+
+export class Literal {
+    value: Int | Bool | Arr;
+
+    constructor(value: Int | Bool | Arr) {
+        this.value = value;
+    }
+
+    toString(): string {
+        return this.value.toString();
+    }
+}
+
 // TODO: update to support n-ary args
 export class Apply {
     fn: Expression;
@@ -82,4 +136,4 @@ export class Letrec {
     }
 }
 
-export type Expression = Lambda | Identifier | Apply | Let | Letrec;
+export type Expression = Lambda | Identifier | Apply | Let | Letrec | Literal;

--- a/hindley-milner/src/types.ts
+++ b/hindley-milner/src/types.ts
@@ -47,6 +47,8 @@ export class TypeVariable {
 /**
  * An n-ary type constructor which builds a new type from old
  */
+// TODO: rename to TypeConstructor or TCon so that it fits better
+// with common terminology
 export class TypeOperator {
   name: string;
   types: Type[];
@@ -90,7 +92,16 @@ export class TFunction extends TypeOperator {
 // Basic types are constructed with a nullary type constructor
 export const TInteger = new TypeOperator("int", []);  // Basic integer
 export const TBool = new TypeOperator("bool", []);  // Basic bool
+export const TAny = new TypeOperator("any", []);  // top type (all types are subtype of this)
+export const TNever = new TypeOperator("never", []);  // bottom type
 
+// TODO: literal types and union (sum) types
+
+// Right now all TypeOperators have an explicit name, but eventually
+// we'd like to support TypeOperators where the name can instead by
+// parameterized by another TypeOperator, e.g.
+// Functor f => (a -> b) -> f a -> f b.
+// TODO: model this as a Scheme, see http://dev.stephendiehl.com/fun/006_hindley_milner.html
 export type Type = TypeVariable | TypeOperator;
 
 export const equal = (t1: Type, t2: Type): boolean => {


### PR DESCRIPTION
For now `Literal` only differentiates between integer, boolean, and array, but not between two integers with different values.  There's still some work to do to figure out how array literals will work.  Right now arrays can only use a single type for all elements.  I think we'll want array literals to be represented by tuples.  That way we can track the type of each element separately.