### PR TITLE
literal types for int and bool and initial sub-typing support

### DIFF
--- a/docs/type_system.md
+++ b/docs/type_system.md
@@ -28,6 +28,37 @@ A subtype can be used any place the original type is used.  This is safe
 because all types except for `ref`s are immutable and the only allowed subtypes
 of `ref<a'>` are `ref<a'>` itself.
 
+### literal types
+
+Literal types are almost the basis of the type system.  This is because
+they can be used for a variety of purposes:
+- tags to discriminate between a union of object/records
+- representing enums
+- typing overloaded functions, e.g. `createElement()`
+
+Literals have an immediate super type, e.g.
+- the type literal for `5` has the immediate super type `int`
+- the type literal for `true` has teh immediate super type `bool`
+
+Union types can be used to represent a type that can take on multiple
+distinct values, e.g. `5 | 10` can be either `5` or `10`.  In the case
+of `true | false`, the union type is equiavlent to `boolean`.
+
+Since union types are essential sets, we can define the normal set
+operations on them:
+- union
+- intersection (don't use this for record/object since it doesn't make sense)
+  given `5 | 10 | 15` and `2 | 3 | 5`, the intersection of the types is `5`.
+  the intersection of `5 | 10 | 15` and `int` is `int` since `int` is a super
+  type of all type literals.
+- difference
+  given `5 | 10 | 15` and `2 | 3 | 5`, the set difference is `10 | 15`
+  the difference of `int` and `5 | 10 | 15` is all integers except for `5 | 10 | 15`.
+- what about complement?
+  depends on the universe of discorse... what happens if we define it to be all
+  types that are representable by the type system?  Does support "complement" offer
+  anything beyond a fancy way of representing set difference?
+
 ### primitives
 
 - a type literal is a subtype for type it's contained within, e.g.
@@ -52,6 +83,13 @@ any partial application of the callback in the function should be done
 as if the callback had the expected number of params even though it
 doesn't.
 
+Representing function args as tuples could help support features like:
+- function overloading (how does this work with function sub-typing)
+  e.g. `createElement('div')` return an `HTMLDivElement`
+  How do we include the return type?
+- rest args (pass multiple args from a tuple)
+  `let args = [5, true] in foo(...args)`
+
 ### objects
 
 - if an object `foo` has all of the fields as `bar` does but `foo` has additional
@@ -62,7 +100,13 @@ doesn't.
 
 ### arrays/tuples
 
-TODO: fill this out
+Array literals can be inferred as tuples.  Tuples will allow a mix of types, e.g.
+`[1, 2, 3]`, `[5, true, "hello"]`.  These will be typed based on the literal that
+they contain.
+
+If the immediate super type of each literal is the same, e.g. `[1, 2, 3]` has the
+following super types: `[int, int, int]` then the tuple can be considered a subtype
+of `int[]`.
 
 ### enums
 
@@ -70,6 +114,10 @@ Enums can be either a subtype of strings or a subtype of numbers (depending on
 what values are used to define them).  This means that if there's a function that
 takes a string we can pass and enum to it.  This could be useful in printing out
 enums (or using them from a select dropdown).
+
+e.g. `enum Color = Red | Green | Blue` is a subtype of `'Red' | 'Green' | 'Blue'`.
+Further more a union of string literals is a subtype of `string` which means any
+function accepting a string could be passed an enum.
 
 ### refs
 
@@ -82,6 +130,11 @@ itself.
 
 TODO: fill this out
 
+How would we define nomminal subtyping, e.g. `HTMLDivElement` is a subtype of
+`HTMLElement` which is a subtype of `Element` which is a subtype of `Node`?  Can
+we define these subclasses in terms of interfaces (object/record) types describe
+the hierarchy in this way?
+
 ## Partial Application
 
 Two approaches:
@@ -91,6 +144,15 @@ Two approaches:
 The former is easier to implement, but has the draw back of not allowing
 flexibility in which params are partially applied.  With `bind` they must
 be applied from left to right with now gaps in between.
+
+## utility types
+
+- keys is union of all property names as string literal types
+- operators on unions (drop elements, add elements)
+- use modified union types to modify object/record types (omit/pick?)
+- if a union type P is a subset of a object/record's keys then we can define
+  a new record from the old one that contains only the entries with keys in P
+  - this new object/record will also be a subtype of the original object/record
 
 ## Other topics
 

--- a/docs/type_system.md
+++ b/docs/type_system.md
@@ -59,6 +59,8 @@ operations on them:
   types that are representable by the type system?  Does support "complement" offer
   anything beyond a fancy way of representing set difference?
 
+How does subtyping fit into this? (especially with objects/records)
+
 ### primitives
 
 - a type literal is a subtype for type it's contained within, e.g.

--- a/hindley-milner/src/infer.ts
+++ b/hindley-milner/src/infer.ts
@@ -19,6 +19,7 @@ import {
   TVar,
   TFunction,
   TInteger,
+  TLit,
   TCon,
   Type,
   equal,
@@ -146,30 +147,23 @@ const getTypeForIdentifier = (
 };
 
 const getTypeForLiteral = (literal: Literal): Type => {
-  if (literal.value instanceof Int) {
-    // TODO: return a literal type, e.g. if the value is 5 then we'd like
-    // to return TIntegerLiteral with a value of 5.  This is a subtype of
-    // TInteger.
-    return TInteger;
+  if (literal instanceof Arr) {
+    // When determining the type of an array literal with values on it,
+    // compute the types of each element.  If we get back a bunch of
+    // TIntegerLiterals, then the type would be TypeOperator("[]", TInteger).
+    // We need a way to map between literal types and their corresponding
+    // minimal containing type.
+
+    // If we have a function like map: a[] -> a[] and we pass in an array
+    // literal with type [5, 10], at that point we need to fine the least
+    // general super type that allows for type unification.  In this case
+    // it would int[].
+
+    // Most of the time we want to maintain the literal type's value unless
+    // unification requires something more general.
+    throw new ParseError(`getTypeForLiteral doesn't handle array literals yet`);
   }
-  if (literal.value instanceof Bool) {
-    return TBool;
-  }
-
-  // When determining the type of an array literal with values on it,
-  // compute the types of each element.  If we get back a bunch of
-  // TIntegerLiterals, then the type would be TypeOperator("[]", TInteger).
-  // We need a way to map between literal types and their corresponding
-  // minimal containing type.
-
-  // If we have a function like map: a[] -> a[] and we pass in an array
-  // literal with type [5, 10], at that point we need to fine the least
-  // general super type that allows for type unification.  In this case
-  // it would int[].
-
-  // Most of the time we want to maintain the literal type's value unless
-  // unification requires something more general.
-  throw new ParseError(`TODO: handle array literals`);
+  return new TLit(literal);
 };
 
 /**
@@ -197,6 +191,8 @@ const fresh = (t: Type, nonGeneric: Set<TVar>): Type => {
       }
     } else if (p instanceof TCon) {
       return new TCon(p.name, p.types.map(freshRec));
+    } else if (p instanceof TLit) {
+      return p;
     }
     throw new Error("freshRec should never get here");
   };
@@ -225,17 +221,71 @@ const unify = (t1: Type, t2: Type) => {
       a.instance = b;
     }
   } else if (a instanceof TCon && b instanceof TVar) {
+    // We reverse the order here so that the previous `if` block can
+    // handle `b` being a `TVar`.
+
+    // Is type unification actually symmetric?  We may want to introduce
+    // behavior in the future that treats l-values and r-values different.
     unify(b, a);
   } else if (a instanceof TCon && b instanceof TCon) {
     if (a.name != b.name || a.types.length != b.types.length) {
+      // When should we expand `int` to `int | bool`?
       throw new InferenceError(`Type mismatch: ${a} != ${b}`);
     }
     for (const [p, q] of zip(a.types, b.types)) {
       unify(p, q);
     }
+  } else if (a instanceof TLit && b instanceof TLit) {
+    // This could be more succinct if we were using a disjoint union instead
+    // of instanceof and classes.
+    if (a.value.value instanceof Int && b.value.value instanceof Int) {
+      if (!equal(a, b)) {
+        maybeWidenTypes(a, b);
+      }
+    } else if (a.value.value instanceof Bool && b.value.value instanceof Bool) {
+      if (!equal(a, b)) {
+        maybeWidenTypes(a, b);
+      }
+    } else {
+      throw new InferenceError(`Type mismatch: ${a} != ${b}`);
+    }
+  } else if (a instanceof TLit) {
+    // TODO: figure out if there's any situations in which we don't want to 
+    // expand a literal type to its super type?
+
+    // Try to unify `b` with `a`'s immediate super type.
+    unify(getSuperType(a), b);
+  } else if (b instanceof TLit) {
+    // Try to unify `a` with `b`'s immediate super type.
+    unify(a, getSuperType(b));
   } else {
     assert.ok(0, "Not unified");
   }
+};
+
+// Are there any situations when only one of the types we're trying to unify
+// needs widening?
+const maybeWidenTypes = (a: TLit, b: TLit) => {
+  if (!a.frozen && !b.frozen) {
+    // TODO: check the existing value of `widening` in case it needs
+    // be widened further.
+
+    // Once we have union types then the widening here should widen
+    // the literals to the union of the two literals instead of using
+    // the immediate super type.
+    a.widening = getSuperType(a);
+    b.widening = getSuperType(b);
+  }
+}
+
+const getSuperType = (t: TLit): TCon => {
+  if (t.value.value instanceof Int) {
+    return TInteger;
+  }
+  if (t.value.value instanceof Bool) {
+    return TBool;
+  }
+  throw new Error(`No super type defined for ${t}`);
 };
 
 /**

--- a/hindley-milner/src/types.ts
+++ b/hindley-milner/src/types.ts
@@ -79,10 +79,12 @@ export class TLit {
 export class TCon {
   name: string;
   types: Type[];
+  frozen: boolean;
 
   constructor(name: string, types: Type[]) {
     this.name = name;
     this.types = types;
+    this.frozen = false;
   }
 
   toString(): string {
@@ -147,4 +149,15 @@ export const equal = (t1: Type, t2: Type): boolean => {
     return t1.value === t2.value;
   }
   return false;
+}
+
+export const freezeType = (t: Type) => {
+  if (t instanceof TCon) {
+    if (!t.frozen) {
+      t.frozen = true;
+      t.types.forEach(freezeType);
+    }
+  } else if (t instanceof TLit) {
+    t.frozen = true;
+  }
 }


### PR DESCRIPTION
Supporting type literals is important for interop with TypeScript/Flow.  Discriminated unions is a common use case for type literals, but they are useful in a variety of other scenarios, e.g. enums, "keys" utility type, overloaded functions.  This PR stats to lay the ground work for some of these more interesting features.

This PR modifies type inference to infer the type of int and bool literals as their type literal equivalent.  For example, the type of the number `3` will be infer as the type literal `3`.  If necessary this type may be widened to `TInteger` in certain circumstances.

We also introduce the concept of frozen types.  This allows us to declare a top-level function, infer its type, and then prevent widening of that type (or any of the types that describe it) when it's used inside of other declarations.