### PR TITLE
Add types, builders, built-ins, and utils to help with type inference

### DIFF
--- a/src/infer/__tests__/printer.test.ts
+++ b/src/infer/__tests__/printer.test.ts
@@ -82,6 +82,17 @@ describe("print", () => {
     });
   });
 
+  describe("TTuple", () => {
+    test('[5, true, "hello"]', () => {
+      const ast = b.tTuple(
+        b.tLit(b.lNum(5)),
+        b.tLit(b.lBool(true)),
+        b.tLit(b.lStr("hello"))
+      );
+      expect(print(ast)).toEqual('[5, true, "hello"]');
+    });
+  });
+
   describe("TUnion", () => {
     test("true | false", () => {
       const ast = b.tUnion(b.tLit(b.lBool(true)), b.tLit(b.lBool(false)));

--- a/src/infer/__tests__/printer.test.ts
+++ b/src/infer/__tests__/printer.test.ts
@@ -1,0 +1,101 @@
+import * as b from "../builders";
+import { print } from "../printer";
+
+describe("print", () => {
+  describe("TLit", () => {
+    test("true", () => {
+      const ast = b.tLit(b.lBool(true));
+      expect(print(ast)).toEqual("true");
+    });
+
+    test("false", () => {
+      const ast = b.tLit(b.lBool(false));
+      expect(print(ast)).toEqual("false");
+    });
+
+    test("5", () => {
+      const ast = b.tLit(b.lNum(5));
+      expect(print(ast)).toEqual("5");
+    });
+
+    test('"hello"', () => {
+      const ast = b.tLit(b.lStr("hello"));
+      expect(print(ast)).toEqual('"hello"');
+    });
+  });
+
+  test("TVar", () => {
+    expect(print(b.tVar())).toEqual("a");
+  });
+
+  describe("TCon", () => {
+    test("Promise<number>", () => {
+      const ast = b.tCon("Promise", [b.tCon("number")]);
+      expect(print(ast)).toEqual("Promise<number>");
+    });
+  });
+
+  describe("TFun", () => {
+    test("() => bool", () => {
+      const ast = b.tFun([], b.tCon("bool"));
+      expect(print(ast)).toEqual("() => bool");
+    });
+
+    test("(number) => number", () => {
+      const num = b.tCon("number");
+      const ast = b.tFun([b.tParam("", num)], num);
+      expect(print(ast)).toEqual("(arg0: number) => number");
+    });
+
+    test("(string, string) => void", () => {
+      const str = b.tCon("string");
+      const ast = b.tFun(
+        [b.tParam("", str), b.tParam("", str)],
+        b.tCon("void")
+      );
+      expect(print(ast)).toEqual("(arg0: string, arg1: string) => void");
+    });
+
+    test("(foo: string, bar?: string) => void", () => {
+      const str = b.tCon("string");
+      const ast = b.tFun(
+        [b.tParam("foo", str), b.tParam("bar", str, true)],
+        b.tCon("void")
+      );
+      expect(print(ast)).toEqual("(foo: string, bar?: string) => void");
+    });
+
+    test("(a) => (b) => c", () => {
+      const ast = b.tFun(
+        [b.tParam("", b.tVar())],
+        b.tFun([b.tParam("", b.tVar())], b.tVar())
+      );
+      expect(print(ast)).toEqual("(arg0: a) => (arg0: b) => c");
+    });
+  });
+
+  describe("TRec", () => {
+    test("{x: number, y?: number", () => {
+      const num = b.tCon("number");
+      const ast = b.tRec(b.tProp("x", num), b.tProp("y", num, true));
+      expect(print(ast)).toEqual("{ x: number, y?: number }");
+    });
+  });
+
+  describe("TUnion", () => {
+    test("true | false", () => {
+      const ast = b.tUnion(b.tLit(b.lBool(true)), b.tLit(b.lBool(false)));
+      expect(print(ast)).toEqual("true | false");
+    });
+
+    test("(int) => void | (string) => void", () => {
+      const ast = b.tUnion(
+        b.tFun([b.tParam("", b.tCon("int"))], b.tCon("void")),
+        b.tFun([b.tParam("", b.tCon("string"))], b.tCon("void"))
+      );
+      expect(print(ast)).toEqual(
+        "((arg0: int) => void) | ((arg0: string) => void)"
+      );
+    });
+  });
+});

--- a/src/infer/__tests__/util.test.ts
+++ b/src/infer/__tests__/util.test.ts
@@ -1,0 +1,524 @@
+import * as b from "../builders";
+import * as builtins from "../builtins";
+import { equal, isSubtypeOf, flatten } from "../util";
+import { print } from "../printer";
+
+describe("equal", () => {
+  test("string literals", () => {
+    const x = b.tLit(b.lStr("hello"));
+    const y = b.tLit(b.lStr("hello"));
+    expect(equal(x, y)).toBe(true);
+
+    const z = b.tLit(b.lStr("goodbye"));
+    expect(equal(x, z)).toBe(false);
+  });
+
+  test("number literals", () => {
+    const x = b.tLit(b.lNum(5));
+    const y = b.tLit(b.lNum(5));
+    expect(equal(x, y)).toBe(true);
+
+    const z = b.tLit(b.lNum(10));
+    expect(equal(x, z)).toBe(false);
+  });
+
+  test("boolean literals", () => {
+    const x = b.tLit(b.lBool(false));
+    const y = b.tLit(b.lBool(false));
+    expect(equal(x, y)).toBe(true);
+
+    const z = b.tLit(b.lBool(true));
+    expect(equal(x, z)).toBe(false);
+  });
+
+  describe("type constructors", () => {
+    test("foo<a>", () => {
+      const a = b.tVar();
+      const x = b.tCon("foo", [a]);
+      const y = b.tCon("foo", [a]);
+      expect(equal(x, y)).toBe(true);
+    });
+
+    test("foo<number>", () => {
+      const x = b.tCon("foo", [builtins.tNumber]);
+      const y = b.tCon("foo", [builtins.tNumber]);
+      expect(equal(x, y)).toBe(true);
+    });
+
+    test("foo<5>", () => {
+      const a = b.tLit(b.lNum(5));
+      const x = b.tCon("foo", [a]);
+      const y = b.tCon("foo", [a]);
+      expect(equal(x, y)).toBe(true);
+    });
+
+    test("foo<number> != foo<string>", () => {
+      const x = b.tCon("foo", [builtins.tNumber]);
+      const y = b.tCon("foo", [builtins.tString]);
+      expect(equal(x, y)).toBe(false);
+    });
+
+    test("foo<a> != foo<a, b>", () => {
+      const a = b.tVar();
+      const x = b.tCon("foo", [a]);
+      const y = b.tCon("foo", [a, b.tVar()]);
+      expect(equal(x, y)).toBe(false);
+    });
+  });
+
+  describe("function types", () => {
+    test("() => number", () => {
+      const f1 = b.tFun([], builtins.tNumber);
+      const f2 = b.tFun([], builtins.tNumber);
+      expect(equal(f1, f2)).toBe(true);
+    });
+
+    test("(number, string) => void", () => {
+      const f1 = b.tFun(
+        [b.tParam("", builtins.tNumber), b.tParam("", builtins.tString)],
+        builtins.tUndefined
+      );
+      const f2 = b.tFun(
+        [b.tParam("", builtins.tNumber), b.tParam("", builtins.tString)],
+        builtins.tUndefined
+      );
+      expect(equal(f1, f2)).toBe(true);
+    });
+
+    test("differences in param names are ignored", () => {
+      const f1 = b.tFun(
+        [b.tParam("foo", builtins.tNumber), b.tParam("bar", builtins.tString)],
+        builtins.tUndefined
+      );
+      const f2 = b.tFun(
+        [b.tParam("x", builtins.tNumber), b.tParam("y", builtins.tString)],
+        builtins.tUndefined
+      );
+      expect(equal(f1, f2)).toBe(true);
+    });
+
+    test("different number of params", () => {
+      const f1 = b.tFun(
+        [b.tParam("", builtins.tNumber), b.tParam("", builtins.tString)],
+        builtins.tUndefined
+      );
+      const f2 = b.tFun([b.tParam("", builtins.tNumber)], builtins.tUndefined);
+      expect(equal(f1, f2)).toBe(false);
+    });
+
+    test("different return types", () => {
+      const f1 = b.tFun(
+        [b.tParam("", builtins.tNumber), b.tParam("", builtins.tString)],
+        builtins.tUndefined
+      );
+      const f2 = b.tFun(
+        [b.tParam("", builtins.tNumber), b.tParam("", builtins.tString)],
+        builtins.tBoolean
+      );
+      expect(equal(f1, f2)).toBe(false);
+    });
+
+    test("different param types", () => {
+      const f1 = b.tFun(
+        [b.tParam("", builtins.tNumber), b.tParam("", builtins.tString)],
+        builtins.tUndefined
+      );
+      const f2 = b.tFun(
+        [b.tParam("", builtins.tNumber), b.tParam("", builtins.tBoolean)],
+        builtins.tUndefined
+      );
+      expect(equal(f1, f2)).toBe(false);
+    });
+
+    test("optional params are the same as `T | undefined`", () => {
+      const f1 = b.tFun(
+        [b.tParam("", builtins.tNumber), b.tParam("", builtins.tString, true)],
+        builtins.tUndefined
+      );
+      const f2 = b.tFun(
+        [
+          b.tParam("", builtins.tNumber),
+          b.tParam("", b.tUnion(builtins.tString, builtins.tUndefined)),
+        ],
+        builtins.tUndefined
+      );
+      expect(equal(f1, f2)).toBe(true);
+    });
+  });
+
+  describe("Record types", () => {
+    test("same", () => {
+      const r1 = b.tRec(
+        b.tProp("x", builtins.tNumber),
+        b.tProp("y", builtins.tString, true)
+      );
+      const r2 = b.tRec(
+        b.tProp("x", builtins.tNumber),
+        b.tProp("y", builtins.tString, true)
+      );
+      expect(equal(r1, r2)).toBe(true);
+    });
+
+    test("different optionality", () => {
+      const r1 = b.tRec(
+        b.tProp("x", builtins.tNumber),
+        b.tProp("y", builtins.tString, true)
+      );
+      const r2 = b.tRec(
+        b.tProp("x", builtins.tNumber),
+        b.tProp("y", builtins.tString)
+      );
+      expect(equal(r1, r2)).toBe(false);
+    });
+
+    test("different property type", () => {
+      const r1 = b.tRec(
+        b.tProp("x", builtins.tNumber),
+        b.tProp("y", builtins.tString, true)
+      );
+      const r2 = b.tRec(
+        b.tProp("x", builtins.tNumber),
+        b.tProp("y", builtins.tBoolean, true)
+      );
+      expect(equal(r1, r2)).toBe(false);
+    });
+
+    test("different property name", () => {
+      const r1 = b.tRec(
+        b.tProp("x", builtins.tNumber),
+        b.tProp("y", builtins.tString, true)
+      );
+      const r2 = b.tRec(
+        b.tProp("x", builtins.tNumber),
+        b.tProp("z", builtins.tString, true)
+      );
+      expect(equal(r1, r2)).toBe(false);
+    });
+
+    test("optional is the same a `T | undefined`", () => {
+      const r1 = b.tRec(
+        b.tProp("x", builtins.tNumber),
+        b.tProp("y", b.tUnion(builtins.tString, builtins.tUndefined))
+      );
+      const r2 = b.tRec(
+        b.tProp("x", builtins.tNumber),
+        b.tProp("y", builtins.tString, true)
+      );
+      // All tests should test both others to ensure that equal is
+      // commutative
+      expect(equal(r1, r2)).toBe(true);
+      // expect(equal(r2, r2)).toBe(true);
+    });
+  });
+
+  test("different type of type", () => {
+    const t1 = builtins.tNumber;
+    const t2 = b.tFun([], builtins.tNumber);
+    expect(equal(t1, t2)).toBe(false);
+  });
+});
+
+describe("isSubtypeOf", () => {
+  describe("literal subtyping", () => {
+    test("5 is a subtype of itself", () => {
+      const result = isSubtypeOf(b.tLit(b.lNum(5)), b.tLit(b.lNum(5)));
+      expect(result).toBe(true);
+    });
+
+    test("5 is a subtype of number", () => {
+      const result = isSubtypeOf(b.tLit(b.lNum(5)), builtins.tNumber);
+      expect(result).toBe(true);
+    });
+
+    test("5 is not a subtype of string", () => {
+      const result = isSubtypeOf(b.tLit(b.lNum(5)), builtins.tString);
+      expect(result).toBe(false);
+    });
+
+    test("true is a subtype of boolean", () => {
+      const result = isSubtypeOf(b.tLit(b.lBool(true)), builtins.tBoolean);
+      expect(result).toBe(true);
+    });
+
+    test("false is a subtype of boolean", () => {
+      const result = isSubtypeOf(b.tLit(b.lBool(false)), builtins.tBoolean);
+      expect(result).toBe(true);
+    });
+
+    test("'hello' is a subtype of string", () => {
+      const result = isSubtypeOf(b.tLit(b.lStr("hello")), builtins.tString);
+      expect(result).toBe(true);
+    });
+
+    test("5 is a subtype of 5 | 10", () => {
+      const t1 = b.tLit(b.lNum(5));
+      const t2 = b.tUnion(b.tLit(b.lNum(5)), b.tLit(b.lNum(10)));
+      const result = isSubtypeOf(t1, t2);
+      expect(result).toBe(true);
+    });
+
+    test("5 | 10 is a subtype of 5 | 10", () => {
+      const t1 = b.tUnion(b.tLit(b.lNum(5)), b.tLit(b.lNum(10)));
+      const t2 = b.tUnion(b.tLit(b.lNum(5)), b.tLit(b.lNum(10)));
+      const result = isSubtypeOf(t1, t2);
+      expect(result).toBe(true);
+    });
+
+    test("5 is a subtype of number | string", () => {
+      const t1 = b.tLit(b.lNum(5));
+      const t2 = b.tUnion(builtins.tNumber, builtins.tString);
+      const result = isSubtypeOf(t1, t2);
+      expect(result).toBe(true);
+    });
+
+    test("5 is not a subtype of 0 | 1", () => {
+      const t1 = b.tLit(b.lNum(5));
+      const t2 = b.tUnion(b.tLit(b.lNum(0)), b.tLit(b.lNum(1)));
+      const result = isSubtypeOf(t1, t2);
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("record subtyping", () => {
+    test("same", () => {
+      const r1 = b.tRec(
+        b.tProp("x", builtins.tNumber),
+        b.tProp("y", builtins.tString, true)
+      );
+      const r2 = b.tRec(
+        b.tProp("x", builtins.tNumber),
+        b.tProp("y", builtins.tString, true)
+      );
+      const result = isSubtypeOf(r1, r2);
+      expect(result).toBe(true);
+    });
+
+    test("the subtype can have extra fields", () => {
+      const r1 = b.tRec(
+        b.tProp("x", builtins.tNumber),
+        b.tProp("y", builtins.tString, true),
+        b.tProp("z", builtins.tBoolean)
+      );
+      const r2 = b.tRec(
+        b.tProp("x", builtins.tNumber),
+        b.tProp("y", builtins.tString, true)
+      );
+      const result = isSubtypeOf(r1, r2);
+      expect(result).toBe(true);
+    });
+
+    test("optional property isn't a subtype of a non-optional one", () => {
+      const r1 = b.tRec(
+        b.tProp("x", builtins.tNumber),
+        b.tProp("y", builtins.tString, true)
+      );
+      const r2 = b.tRec(
+        b.tProp("x", builtins.tNumber),
+        b.tProp("y", builtins.tString)
+      );
+      const result = isSubtypeOf(r1, r2);
+      expect(result).toBe(false);
+    });
+
+    test("non-optional property is a subtype of a optional one", () => {
+      const r1 = b.tRec(
+        b.tProp("x", builtins.tNumber),
+        b.tProp("y", builtins.tString)
+      );
+      const r2 = b.tRec(
+        b.tProp("x", builtins.tNumber),
+        b.tProp("y", builtins.tString, true)
+      );
+      const result = isSubtypeOf(r1, r2);
+      expect(result).toBe(true);
+    });
+
+    test("the subtype can't have fewer fields", () => {
+      const r1 = b.tRec(b.tProp("x", builtins.tNumber));
+      const r2 = b.tRec(
+        b.tProp("x", builtins.tNumber),
+        b.tProp("y", builtins.tString, true)
+      );
+      const result = isSubtypeOf(r1, r2);
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("function sub-typing", () => {
+    test("same", () => {
+      const f1 = b.tFun(
+        [b.tParam("", builtins.tNumber), b.tParam("", builtins.tString)],
+        builtins.tBoolean
+      );
+      const f2 = b.tFun(
+        [b.tParam("", builtins.tNumber), b.tParam("", builtins.tString)],
+        builtins.tBoolean
+      );
+
+      const result = isSubtypeOf(f1, f2);
+      expect(result).toBe(true);
+    });
+
+    test("return type is a subtype", () => {
+      const f1 = b.tFun(
+        [b.tParam("", builtins.tNumber), b.tParam("", builtins.tString)],
+        builtins.tTrue
+      );
+      const f2 = b.tFun(
+        [b.tParam("", builtins.tNumber), b.tParam("", builtins.tString)],
+        builtins.tBoolean
+      );
+
+      const result = isSubtypeOf(f1, f2);
+      expect(result).toBe(true);
+    });
+
+    test("not a subtype if return type is a supertype", () => {
+      const f1 = b.tFun(
+        [b.tParam("", builtins.tNumber), b.tParam("", builtins.tString)],
+        builtins.tBoolean
+      );
+      const f2 = b.tFun(
+        [b.tParam("", builtins.tNumber), b.tParam("", builtins.tString)],
+        builtins.tTrue
+      );
+
+      const result = isSubtypeOf(f1, f2);
+      expect(result).toBe(false);
+    });
+
+    test("is a subtype if arg type is a supertype", () => {
+      // f1 = (x: number, y: string) => boolean
+      const f1 = b.tFun(
+        [b.tParam("", builtins.tNumber), b.tParam("", builtins.tString)],
+        builtins.tBoolean
+      );
+      // f2 = (x: 5, y: string) => boolean
+      const f2 = b.tFun(
+        [b.tParam("", b.tLit(b.lNum(5))), b.tParam("", builtins.tString)],
+        builtins.tBoolean
+      );
+
+      // f2(5, "hello") is valid and so is f1(5, "hello") because f1 accepts
+      // all numbers
+      const result = isSubtypeOf(f1, f2);
+      expect(result).toBe(true);
+    });
+
+    test("is not a subtype if arg type is a subtype", () => {
+      // f1 = (x: 5, y: string) => boolean
+      const f1 = b.tFun(
+        [b.tParam("", b.tLit(b.lNum(5))), b.tParam("", builtins.tString)],
+        builtins.tBoolean
+      );
+      // f2 = (x: number, y: string) => boolean
+      const f2 = b.tFun(
+        [b.tParam("", builtins.tNumber), b.tParam("", builtins.tString)],
+        builtins.tBoolean
+      );
+
+      // f2(10, "hello") is valid, but f1(10, "hello") is not
+      const result = isSubtypeOf(f1, f2);
+      expect(result).toBe(false);
+    });
+
+    test("having fewer params is a subtype", () => {
+      const f1 = b.tFun([b.tParam("", builtins.tNumber)], builtins.tBoolean);
+      const f2 = b.tFun(
+        [b.tParam("", builtins.tNumber), b.tParam("", builtins.tString)],
+        builtins.tBoolean
+      );
+
+      const result = isSubtypeOf(f1, f2);
+      expect(result).toBe(true);
+    });
+
+    test("having more params is not a subtype", () => {
+      const f1 = b.tFun(
+        [
+          b.tParam("", builtins.tNumber),
+          b.tParam("", builtins.tString),
+          b.tParam("", builtins.tNumber),
+        ],
+        builtins.tBoolean
+      );
+      const f2 = b.tFun(
+        [b.tParam("", builtins.tNumber), b.tParam("", builtins.tString)],
+        builtins.tBoolean
+      );
+
+      const result = isSubtypeOf(f1, f2);
+      expect(result).toBe(false);
+    });
+
+    test("all extra params are optional makes it a subtype", () => {
+      // This is because it's okay to call the function without those
+      // extra params.
+      const f1 = b.tFun(
+        [
+          b.tParam("", builtins.tNumber),
+          b.tParam("", builtins.tString),
+          b.tParam("", builtins.tBoolean, true),
+        ],
+        builtins.tBoolean
+      );
+      const f2 = b.tFun(
+        [b.tParam("", builtins.tNumber), b.tParam("", builtins.tString)],
+        builtins.tBoolean
+      );
+
+      const result = isSubtypeOf(f1, f2);
+      expect(result).toBe(true);
+    });
+  });
+
+  describe("type var", () => {
+    test("subtype of itself", () => {
+      let t = b.tVar();
+
+      expect(isSubtypeOf(t, t)).toBe(true);
+    });
+  });
+});
+
+describe("flatten", () => {
+  test("3 | 5 | number -> number", () => {
+    const t = b.tUnion(b.tLit(b.lNum(3)), b.tLit(b.lNum(5)), builtins.tNumber);
+
+    const result = flatten(t);
+
+    expect(print(result)).toEqual("number");
+  });
+
+  test("5 | (10 | number) -> number", () => {
+    const t = b.tUnion(
+      b.tLit(b.lNum(5)),
+      b.tUnion(b.tLit(b.lNum(5)), builtins.tNumber)
+    );
+
+    const result = flatten(t);
+
+    expect(print(result)).toEqual("number");
+  });
+
+  test("(a | b) | (c | d) -> a | b | c | d", () => {
+    const l = b.tUnion(b.tVar(), b.tVar());
+    const r = b.tUnion(b.tVar(), b.tVar());
+    const t = b.tUnion(l, r);
+
+    const result = flatten(t);
+
+    expect(print(result)).toEqual("a | b | c | d");
+  });
+
+  test("(a | b) | (b | c) -> a | b | c", () => {
+    const at = b.tVar();
+    const bt = b.tVar();
+    const ct = b.tVar();
+    const t = b.tUnion(b.tUnion(at, bt), b.tUnion(bt, ct));
+
+    const result = flatten(t);
+
+    expect(print(result)).toEqual("a | b | c");
+  });
+});

--- a/src/infer/builders.ts
+++ b/src/infer/builders.ts
@@ -1,0 +1,60 @@
+import * as t from "./types";
+import { getId } from "./core";
+
+export const lBool = (value: boolean): t.LBool => {
+  return { t: "LBool", value };
+};
+
+export const lNum = (value: number): t.LNum => {
+  return { t: "LNum", value };
+};
+
+export const lStr = (value: string): t.LStr => {
+  return { t: "LStr", value };
+};
+
+export const tLit = (literal: t.Literal): t.TLiteral => {
+  return { t: "TLit", literal };
+};
+
+export const tVar = (): t.TVar => {
+  return { t: "TVar", id: getId() };
+};
+
+export const tCon = (
+  name: string,
+  typeArgs: readonly t.Type[] = []
+): t.TCon => {
+  return { t: "TCon", name, typeArgs };
+};
+
+export const tFun = (
+  paramTypes: readonly t.TParam[],
+  retType: t.Type
+): t.TFun => {
+  return { t: "TFun", paramTypes, retType };
+};
+
+export const tRec = (...properties: readonly t.TProp[]): t.TRec => {
+  return { t: "TRec", properties };
+};
+
+export const tProp = (
+  name: string,
+  type: t.Type,
+  optional = false // TODO: make this an enum instead
+): t.TProp => {
+  return { t: "TProp", name, type, optional };
+};
+
+export const tParam = (
+  name: string,
+  type: t.Type,
+  optional = false
+): t.TParam => {
+  return { t: "TParam", name, type, optional };
+};
+
+export const tUnion = (...types: readonly t.Type[]): t.TUnion => {
+  return { t: "TUnion", types };
+};

--- a/src/infer/builders.ts
+++ b/src/infer/builders.ts
@@ -55,6 +55,10 @@ export const tParam = (
   return { t: "TParam", name, type, optional };
 };
 
+export const tTuple = (...types: readonly t.Type[]): t.TTuple => {
+  return { t: "TTuple", types };
+};
+
 export const tUnion = (...types: readonly t.Type[]): t.TUnion => {
   return { t: "TUnion", types };
 };

--- a/src/infer/builtins.ts
+++ b/src/infer/builtins.ts
@@ -1,0 +1,16 @@
+import * as b from './builders';
+
+export const tTrue = b.tLit(b.lBool(true)); 
+export const tFalse = b.tLit(b.lBool(false));
+
+export const tUndefined = b.tCon('undefined');
+export const tNumber = b.tCon('number');
+export const tBoolean = b.tCon('boolean');
+export const tString = b.tCon('string');
+
+// TODO: figure out how to model methods and getters
+// .map(), .forEach(), .length
+export const tArray = b.tCon('Array', [b.tVar()]);
+// .then(), .catch()
+export const tPromise = b.tCon('Promise', [b.tVar()]);
+// These are essentially parameterized object types

--- a/src/infer/core.ts
+++ b/src/infer/core.ts
@@ -1,0 +1,4 @@
+let id = 0;
+export const getId = () => {
+  return id++;
+}

--- a/src/infer/printer.ts
+++ b/src/infer/printer.ts
@@ -48,6 +48,9 @@ export const print = (t: Type): string => {
         );
         return `{ ${properties.join(', ')} }`;
       }
+      case 'TTuple': {
+        return `[${t.types.map(_print).join(', ')}]`;
+      }
       case 'TUnion': {
         const types = t.types.map((t) =>
           t.t === 'TFun' ? `(${_print(t)})` : _print(t)

--- a/src/infer/printer.ts
+++ b/src/infer/printer.ts
@@ -1,0 +1,61 @@
+import type { Type } from "./types";
+
+export const print = (t: Type): string => {
+  const tVarNames: Record<number, string> = {};
+  let nextName: string = "a";
+
+  const _print = (t: Type): string => {
+    switch (t.t) {
+      case 'TLit': {
+        const l = t.literal;
+        switch (l.t) {
+          case 'LBool':
+            return l.value.toString();
+          case 'LNum':
+            return l.value.toString();
+          case 'LStr':
+            return `"${l.value}"`;
+        }
+      }
+      case 'TVar': {
+        if (!tVarNames[t.id]) {
+          tVarNames[t.id] = nextName;
+          nextName = String.fromCharCode(nextName.charCodeAt(0) + 1);
+        }
+        return tVarNames[t.id];
+      }
+      case 'TCon': {
+        const typeArgs = t.typeArgs.map(_print);
+        return typeArgs.length > 0
+          ? `${t.name}<${typeArgs.join(', ')}>`
+          : t.name;
+      }
+      case 'TFun': {
+        const paramTypes = t.paramTypes.map((p, i) => {
+          const name = p.name || `arg${i}`;
+          return p.optional 
+            ? `${name}?: ${_print(p.type)}`
+            : `${name}: ${_print(p.type)}`
+        });
+        const retType = _print(t.retType);
+        return `(${paramTypes.join(', ')}) => ${retType}`;
+      }
+      case 'TRec': {
+        const properties = t.properties.map((p) =>
+          p.optional
+            ? `${p.name}?: ${_print(p.type)}`
+            : `${p.name}: ${_print(p.type)}`
+        );
+        return `{ ${properties.join(', ')} }`;
+      }
+      case 'TUnion': {
+        const types = t.types.map((t) =>
+          t.t === 'TFun' ? `(${_print(t)})` : _print(t)
+        );
+        return types.join(' | ');
+      }
+    }
+  };
+
+  return _print(t);
+};

--- a/src/infer/types.ts
+++ b/src/infer/types.ts
@@ -18,51 +18,54 @@
 //   must be an instance of a given type class.
 
 export type LBool = {
-  t: 'LBool';
+  t: "LBool";
   value: boolean;
 };
 
 export type LNum = {
-  t: 'LNum';
+  t: "LNum";
   value: number;
 };
 
 export type LStr = {
-  t: 'LStr';
+  t: "LStr";
   value: string;
 };
 
 export type Literal = LBool | LNum | LStr;
 
 export type TLiteral = {
-  t: 'TLit';
+  t: "TLit";
   // should we share types for literals with the syntax tree?
   literal: Literal;
 };
 
+// TODO: constraints on type variables
 export type TVar = {
-  t: 'TVar';
+  t: "TVar";
   id: number;
 };
 
-// can we use this for tuples as well?
+// TODO: default + optional type args
 export type TCon = {
-  t: 'TCon';
+  t: "TCon";
   name: string; // how do we disambiguate across files?
-  typeArgs: readonly Type[]; // how do we enforce that Promise<> only takes a single type arg?
-  // if the argTypes in TFunction are named, we could also make the type args here
-  // named as well
+  typeArgs: readonly Type[]; 
+  // TODO:
+  // - how do we enforce that Array<> and Promise<> only take a single type arg?
+  // - if the argTypes in TFunction are named, we could also make the type args here
+  //   named as well
 };
 
 export type TParam = {
-  t: 'TParam';
+  t: "TParam";
   name: string;
   type: Type;
   optional: boolean;
 };
 
 export type TFun = {
-  t: 'TFun';
+  t: "TFun";
   // TODO: support optional params, this needs to be done during parsing, since
   // argTypes can reference param types of the Lambda or arg types of the Apply.
   paramTypes: readonly TParam[]; // we could make these named
@@ -70,26 +73,40 @@ export type TFun = {
 };
 
 export type TRec = {
-  t: 'TRec';
+  t: "TRec";
   // if properties was an object, we could look up each property by
   // its name.
   properties: readonly TProp[];
 };
 
 export type TProp = {
-  t: 'TProp';
+  t: "TProp";
   name: string; // could we also use TLiteral here as well?
   type: Type;
   optional: boolean; // this is equivalent to `T | undefined`
 };
 
-export type TUnion = {
-  t: 'TUnion',
-  types: readonly Type[],
+export type TTuple = {
+  t: "TTuple";
+  types: readonly Type[];
 };
 
-export type Type = TLiteral | TVar | TCon | TFun | TRec | TUnion;
+export type TUnion = {
+  t: "TUnion";
+  types: readonly Type[];
+};
+
+export type Type = 
+  | TLiteral  // 5, false, "hello"
+  | TVar      // a, b, etc.
+  | TCon      // Array<number>, Promise<a>
+  | TFun      // (number, string) => boolean
+  | TRec      // {x: number, y?: string}
+  | TTuple    // [number, string]
+  | TUnion;   // number | string
 
 // TODO:
+// - add `.frozen` property to each type so that we can't prevent widening
+//   after a top-level declaration's type has been inferred.
 // - do we need to differentiate between records and objects or
 //   arrays and tuples to support https://github.com/tc39/proposal-record-tuple?

--- a/src/infer/types.ts
+++ b/src/infer/types.ts
@@ -1,0 +1,95 @@
+// Types:
+// - type literal, e.g. `5`, `"hello"`, `true`
+// - type variable, e.g. `a`
+// - type constructor, e.g. `Array<a>`, `Promise<a>`, `Tuple<a, b, c>`
+// - type function (specialized type constructor)
+//   - zero or more param types + one return type
+// - type record (specialzed type constructor)
+//   - contains multiple type properties (key + type)
+
+// Related concepts:
+// - type class, one or more functions and/or values that conform to
+//   certain laws.  If these functions and/or values are defined for
+//   a particular type, then that type is said to be an "instance" of
+//   the given type class.  Type classes can be extended, e.g. Monoid
+//   extends Semigroup.  An example of a type class that containining
+//   a value is Monoid which adds the `mempty` value to Semigroup.
+// - type constraint, e.g. describes what type class a type variable
+//   must be an instance of a given type class.
+
+export type LBool = {
+  t: 'LBool';
+  value: boolean;
+};
+
+export type LNum = {
+  t: 'LNum';
+  value: number;
+};
+
+export type LStr = {
+  t: 'LStr';
+  value: string;
+};
+
+export type Literal = LBool | LNum | LStr;
+
+export type TLiteral = {
+  t: 'TLit';
+  // should we share types for literals with the syntax tree?
+  literal: Literal;
+};
+
+export type TVar = {
+  t: 'TVar';
+  id: number;
+};
+
+// can we use this for tuples as well?
+export type TCon = {
+  t: 'TCon';
+  name: string; // how do we disambiguate across files?
+  typeArgs: readonly Type[]; // how do we enforce that Promise<> only takes a single type arg?
+  // if the argTypes in TFunction are named, we could also make the type args here
+  // named as well
+};
+
+export type TParam = {
+  t: 'TParam';
+  name: string;
+  type: Type;
+  optional: boolean;
+};
+
+export type TFun = {
+  t: 'TFun';
+  // TODO: support optional params, this needs to be done during parsing, since
+  // argTypes can reference param types of the Lambda or arg types of the Apply.
+  paramTypes: readonly TParam[]; // we could make these named
+  retType: Type;
+};
+
+export type TRec = {
+  t: 'TRec';
+  // if properties was an object, we could look up each property by
+  // its name.
+  properties: readonly TProp[];
+};
+
+export type TProp = {
+  t: 'TProp';
+  name: string; // could we also use TLiteral here as well?
+  type: Type;
+  optional: boolean; // this is equivalent to `T | undefined`
+};
+
+export type TUnion = {
+  t: 'TUnion',
+  types: readonly Type[],
+};
+
+export type Type = TLiteral | TVar | TCon | TFun | TRec | TUnion;
+
+// TODO:
+// - do we need to differentiate between records and objects or
+//   arrays and tuples to support https://github.com/tc39/proposal-record-tuple?

--- a/src/infer/util.ts
+++ b/src/infer/util.ts
@@ -1,0 +1,195 @@
+import * as b from "./builders";
+import * as t from "./types";
+import * as builtins from "./builtins";
+
+// Flattens nested union types and removes duplicates.  Subtypes of other
+// elements in the union will be removed.  If there is only a single element
+// remaining, then that type will be return instead of a union type.
+// e.g. flatten(number | (5 | 10)) -> number
+export const flatten = (union: t.TUnion): t.Type => {
+  const types = union.types.flatMap((t) => {
+    if (t.t === "TUnion") {
+      const flattened = flatten(t);
+      return flattened.t === "TUnion" ? flattened.types : [flattened];
+    }
+    return [t];
+  });
+  const uniqueTypes: t.Type[] = [];
+  types.forEach((t, i) => {
+    const remainingTypes = types.slice(i + 1);
+    if (!remainingTypes.some((rt) => isSubtypeOf(t, rt))) {
+      uniqueTypes.push(t);
+    }
+  });
+  // TODO: assert uniqueTypes.length > 0
+  return uniqueTypes.length === 1 ? uniqueTypes[0] : b.tUnion(...uniqueTypes);
+};
+
+// TODO: How do report errors if we wrap types like this to do comparisons?
+const makeOptional = (x: t.Type): t.Type => {
+  return flatten(b.tUnion(x, builtins.tUndefined));
+};
+
+export const getPropType = (x: t.TProp): t.Type =>
+  x.optional ? makeOptional(x.type) : x.type;
+
+export const getParamType = (x: t.TParam): t.Type =>
+  x.optional ? makeOptional(x.type) : x.type;
+
+const propsEqual = (x: t.TProp, y: t.TProp): boolean => {
+  if (x.name !== y.name) {
+    return false;
+  }
+  return equal(getPropType(x), getPropType(y));
+};
+
+// NOTE: this function should only be used by isSubtypeOf since
+// it treats a -> a the same as b -> b.
+export const equal = (x: t.Type, y: t.Type): boolean => {
+  if (x.t === "TCon" && y.t === "TCon") {
+    return (
+      x.name === y.name &&
+      x.typeArgs.length === y.typeArgs.length &&
+      zip(x.typeArgs, y.typeArgs).every((pair) => equal(...pair))
+    );
+  } else if (x.t === "TLit" && y.t === "TLit") {
+    return x.literal.value === y.literal.value;
+  } else if (x.t === "TUnion" && y.t === "TUnion") {
+    return (
+      x.types.every((elem) => isSubtypeOf(elem, y)) &&
+      y.types.every((elem) => isSubtypeOf(elem, x))
+    );
+  } else if (x.t === "TVar" && y.t === "TVar") {
+    return x.id === y.id;
+  } else if (x.t === "TFun" && y.t === "TFun") {
+    // TODO: treat a -> a as being equivalent to b -> b
+    return (
+      x.paramTypes.length === y.paramTypes.length &&
+      zip(x.paramTypes, y.paramTypes).every(([xArg, yArg]) =>
+        equal(getParamType(xArg), getParamType(yArg))
+      ) &&
+      equal(x.retType, y.retType)
+    );
+  } else if (x.t === "TRec" && y.t === "TRec") {
+    return (
+      x.properties.length === y.properties.length &&
+      // we can't use zip here because order is not enforced
+      x.properties.every((aProp) =>
+        y.properties.some((bProp) => propsEqual(aProp, bProp))
+      )
+    );
+  }
+
+  return false;
+};
+
+// We need ways to determine if one type is a subtype or not.
+// A type `foo` is a subtype of `bar` if any value of type `foo`
+// can be used where a `bar` is expected.
+// A result of this definition is that any type is a subtype of
+// itself.
+
+/**
+ * Returns true if `x` is a subtype of `y`.
+ */
+export const isSubtypeOf = (x: t.Type, y: t.Type): boolean => {
+  if (equal(x, y)) {
+    return true;
+  }
+
+  if (y.t === "TUnion") {
+    return y.types.some((elem) => isSubtypeOf(x, elem));
+  }
+
+  switch (x.t) {
+    case "TLit": {
+      const l = x.literal;
+      switch (l.t) {
+        case "LBool":
+          return equal(y, builtins.tBoolean);
+        case "LNum":
+          return equal(y, builtins.tNumber);
+        case "LStr":
+          return equal(y, builtins.tString);
+      }
+    }
+    case "TRec": {
+      if (y.t === "TRec") {
+        return y.properties.every((yProp) => {
+          return x.properties.find((xProp) => {
+            return isSubtypeOf(getPropType(xProp), getPropType(yProp));
+          });
+        });
+      }
+      return false;
+    }
+    case "TFun": {
+      // How do optional params fit into function subtyping and partial application?
+      // When we do partial application check, we just need to see if all of the params
+      // after the ones that have args are option.  If they are all option, then we
+      // do full application of the function.  When applying args to optional params
+      // we have to type check them.  Typescript allows applying `undefined` as an
+      // arg to an optional param.
+
+      // Partial application and function subtyping:
+      // Normally we do partial application if we pass fewer params than is required,
+      // by a function.  Function subtyping says that it's okay to use a function with
+      // fewer params where one with more params is expected, e.g.
+      // if we have map((elem, index) => ...) then we can pass map((elem) => ...)
+      // if `map` partially applies the callback passed in with a single arg, then
+      // if we passed a single arg to a callback that only takes a single arg, we'd
+      // expect the function to just get called.  That means in order for function
+      // subtyping to work, we need to base our decision about whether to do partial
+      // application on the type of the callback param and not the callback arg we're
+      // passed.  This means than we will also be partially applying the callback that
+      // takes a single param.
+      // In this example `let map = (fn : (a, int) -> b, arr) => { fn(x)(0) }` should
+      // work with both `map((elem, index) => ...)` and `map((elem) => ...)`.  In the
+      // second situation the code generated for `fn(x)(0)` would be:
+      // fn.bind(null, x).bind(null, 0).  In both case .bind() returns a new function
+      // even if `fn` doesn't have enough params to begin with accept args for each
+      // .bind() call.
+      // TODO: write some evaluation tests to make sure this works as expected
+      if (y.t === "TFun") {
+        if (x.paramTypes.length > y.paramTypes.length) {
+          // We can't use `x` wherever `y` is used, because it needs more args,
+          // unless all the unfulfilled args are all optional (aka, `undefined`
+          // is a subtype the param).
+          const remainingParamTypes = x.paramTypes.slice(y.paramTypes.length);
+          const isOptional = (p: t.TParam): boolean =>
+            isSubtypeOf(builtins.tUndefined, getParamType(p));
+          if (!remainingParamTypes.every(isOptional)) {
+            return false;
+          }
+        }
+        return (
+          zip(x.paramTypes, y.paramTypes).every(
+            // The direct of the subtype relation is reverse here.  We want
+            // to allow `x` to be used anywhere `y` is used, so any arg we
+            // pass to `y` should be accepted by `x`.  If the first arg of
+            // `y` only accepts `5`, it's okay if the first arg of `x` to
+            // accept numbers.
+            ([xArg, yArg]) =>
+              isSubtypeOf(getParamType(yArg), getParamType(xArg))
+          ) && isSubtypeOf(x.retType, y.retType)
+        );
+      }
+      return false;
+    }
+  }
+
+  return false;
+};
+
+// Type Constructor subtyping:
+// Array<3 | 5> is a subtype of Array<int> becuase
+// `3 | 5` is a subtype of `int`.
+
+export const zip = <T>(xs: readonly T[], ys: readonly T[]): [T, T][] => {
+  const length = Math.min(xs.length, ys.length);
+  const result: [T, T][] = [];
+  for (let i = 0; i < length; i++) {
+    result[i] = [xs[i], ys[i]];
+  }
+  return result;
+};


### PR DESCRIPTION
This doesn't do anything to add type inference itself to the main compiler code, but provides some of the building blocks we'll need to do so in the future.