### PR TITLE
Improve type widening

### DIFF
--- a/src/infer/__tests__/infer.test.ts
+++ b/src/infer/__tests__/infer.test.ts
@@ -135,7 +135,6 @@ describe("infer", () => {
 
     if (ast.body[0].tag !== "Decl") {
       const annAst = infer(ast.body[0], env);
-      // console.log("annAst = ", JSON.stringify(annAst, null, 2));
       expect(print(annAst.ann)).toEqual('(f: (arg0: number | boolean) => a) => "hello"');
     }
   });

--- a/src/infer/__tests__/infer.test.ts
+++ b/src/infer/__tests__/infer.test.ts
@@ -28,7 +28,7 @@ describe("infer", () => {
   test("(f:ignore) => {f(5) + 10}", () => {
     const ast = parse("(f:ignore) => {f(5) + 10};");
     const env = new Map<string, t.Type>();
-    const frozenNumber = JSON.parse(JSON.stringify(builtins.tNumber));
+    const frozenNumber = builtins.tNumber();
     frozenNumber.frozen = true;
     env.set(
       "+",
@@ -50,7 +50,7 @@ describe("infer", () => {
   test('(f:ignore) => {let x = f(5) + f(10); "hello"};', () => {
     const ast = parse('(f:ignore) => {let x = f(5) + f(10); "hello"};');
     const env = new Map<string, t.Type>();
-    const frozenNumber = JSON.parse(JSON.stringify(builtins.tNumber));
+    const frozenNumber = builtins.tNumber();
     frozenNumber.frozen = true;
     env.set(
       "+",
@@ -72,7 +72,7 @@ describe("infer", () => {
   test('(f:ignore) => {let x = f(5); let y = f(10); "hello"};', () => {
     const ast = parse('(f:ignore) => {let x = f(5); let y = f(10); "hello"};');
     const env = new Map<string, t.Type>();
-    const frozenNumber = JSON.parse(JSON.stringify(builtins.tNumber));
+    const frozenNumber = builtins.tNumber();
     frozenNumber.frozen = true;
     env.set(
       "+",
@@ -91,7 +91,7 @@ describe("infer", () => {
   test("widening is flattend, i.e. 5 | number -> number", () => {
     const ast = parse('(f:ignore) => {let x = f(foo); let y = f(10); "hello"};');
     const env = new Map<string, t.Type>();
-    const frozenNumber = JSON.parse(JSON.stringify(builtins.tNumber));
+    const frozenNumber = builtins.tNumber();
     frozenNumber.frozen = true;
     env.set(
       "+",
@@ -100,7 +100,7 @@ describe("infer", () => {
         frozenNumber
       )
     );
-    env.set("foo", clone(builtins.tNumber));
+    env.set("foo", builtins.tNumber());
 
     if (ast.body[0].tag !== "Decl") {
       const annAst = infer(ast.body[0], env);
@@ -111,7 +111,7 @@ describe("infer", () => {
   test("widening can create union types with different type constructors", () => {
     const ast = parse('(f:ignore) => {let x = f(foo); let y = f(bar); "hello"};');
     const env = new Map<string, t.Type>();
-    const frozenNumber = JSON.parse(JSON.stringify(builtins.tNumber));
+    const frozenNumber = builtins.tNumber();
     frozenNumber.frozen = true;
     env.set(
       "+",
@@ -126,9 +126,9 @@ describe("infer", () => {
     // NOTE: we must clone these types otherwise they any widening is shared across
     // all uses of tNumber and tBoolean.
     // TODO: change these to be factories instead of singletons
-    const fooType = clone(builtins.tNumber);
+    const fooType = builtins.tNumber();
     // fooType.frozen = true;
-    const barType = clone(builtins.tBoolean);
+    const barType = builtins.tBoolean();
     // barType.frozen = true;
     env.set("foo", fooType);
     env.set("bar", barType);
@@ -142,7 +142,7 @@ describe("infer", () => {
   test.skip("widening can create union types with different type constructors (frozen args)", () => {
     const ast = parse('(f:ignore) => {let x = f(foo); let y = f(bar); "hello"};');
     const env = new Map<string, t.Type>();
-    const frozenNumber = JSON.parse(JSON.stringify(builtins.tNumber));
+    const frozenNumber = builtins.tNumber();
     frozenNumber.frozen = true;
     env.set(
       "+",
@@ -157,9 +157,9 @@ describe("infer", () => {
     // NOTE: we must clone these types otherwise they any widening is shared across
     // all uses of tNumber and tBoolean.
     // TODO: change these to be factories instead of singletons
-    const fooType = clone(builtins.tNumber);
+    const fooType = builtins.tNumber();
     fooType.frozen = true;
-    const barType = clone(builtins.tBoolean);
+    const barType = builtins.tBoolean();
     barType.frozen = true;
     env.set("foo", fooType);
     env.set("bar", barType);
@@ -178,7 +178,7 @@ describe("infer", () => {
     // we can freeze them.  This will signify two things:
     // - their types can't be widened
     // - they accept subtypes as args
-    const frozenNumber = JSON.parse(JSON.stringify(builtins.tNumber));
+    const frozenNumber = builtins.tNumber();
     frozenNumber.frozen = true;
     env.set(
       "+",
@@ -229,7 +229,7 @@ describe("infer", () => {
 
   test("pass a tuple to a function expecting an array", () => {
     const env = new Map<string, t.Type>();
-    const frozenNumber = JSON.parse(JSON.stringify(builtins.tNumber));
+    const frozenNumber = builtins.tNumber();
     frozenNumber.frozen = true;
     const frozenArray = builtins.tArray(frozenNumber);
     frozenArray.frozen = true;

--- a/src/infer/__tests__/ml-infer.test.ts
+++ b/src/infer/__tests__/ml-infer.test.ts
@@ -1,0 +1,94 @@
+// TODO: port the tests from hindly-milner/src/__tests__/infer.test.ts
+import { Type } from "../types";
+import * as build from "../builders";
+import { parse } from "../../parser";
+import { print as printProgram } from "../../printer";
+import { print} from "../printer";
+import { infer } from "../infer";
+
+describe("hindley-milner type inference", () => {
+  let my_env: Map<string, Type>;
+
+  beforeEach(() => {
+    my_env = new Map();
+
+    const var1 = build.tVar();
+    const var2 = build.tVar();
+    const pair_type = build.tCon("*", [var1, var2]);
+
+    my_env = new Map();
+    // pair is curried
+    my_env.set(
+      "pair",
+      build.tFun(
+        [build.tParam("", var1), build.tParam("", var2)],
+        pair_type,
+      )
+    );
+
+    //   // tuple2 is the uncurried equivalent
+    //   tuple2: build.tFun([var1, var2], pair_type),
+    //   cond: build.tFun(
+    //     [TBool],
+    //     build.tFun([var1], build.tFun([var1], var1))
+    //   ),
+    //   zero: build.tFun([TInteger], TBool),
+    //   pred: build.tFun([TInteger], TInteger),
+    //   times: build.tFun([TInteger], build.tFun([TInteger], TInteger)),
+    //   // TODO: figure out how to implement constrained generics, e.g.
+    //   // const foo: <T: number | string>(T, T) => T
+    //   add: build.tFun([TInteger, TInteger], TInteger),
+    //   // returns an empty array
+    //   empty: build.tFun([], new TCon("[]", [TAny])),
+    // });
+  });
+
+  test("pair(f(4), f(true))", () => {
+    const ast = parse("pair(f(4), f(true));");
+
+    // TODO: improve the printer so we aren't wrapping the function identifier
+    // in parens for each function call.
+    expect(printProgram(ast)).toEqual("(pair)((f)(4), (f)(true))");
+
+    if (ast.body[0].tag !== "Decl") {
+      expect(() => {
+        // @ts-expect-error
+        infer(ast.body[0], my_env);
+      }).toThrowErrorMatchingInlineSnapshot(`"variable \\"f\\" not defined"`);
+    }
+  });
+
+  test.skip("(let g = (fn f => 5) in (g g))", () => {
+    // we can pass anything as the `f` param since it's ignored
+    // the result of g(g) is an int is g always returns 5
+    // TODO: update parser so that we can port the test cases
+    const ast = parse("(let g = (f:ignore) => {5}; g(g))")
+    
+    // new Let(
+    //   "g",
+    //   new Lambda("f", new Literal(new Int(5))),
+    //   new Apply(new Identifier("g"), new Identifier("g"))
+    // );
+
+    // const t = analyze(ast, my_env);
+
+    // expect(ast.toString()).toEqual("(let g = (fn f => 5) in (g g))");
+    // expect(t.toString()).toEqual("5");
+  });
+
+  test("(fn g => (let f = (fn x => g) in ((pair (f 3)) (f true))))", () => {
+    const ast = parse("(g:ignored) => {let f = (x:ignored) => g; pair(f(3), f(true))};");
+    
+    expect(printProgram(ast)).toMatchInlineSnapshot(`
+"(g:ignored) => {
+let f = (x:ignored) => g
+(pair)((f)(3), (f)(true))
+}"
+`)
+
+    if (ast.body[0].tag !== "Decl") {
+      const annAst = infer(ast.body[0], my_env);
+      expect(print(annAst.ann)).toEqual('(g: a) => *<a, a>');
+    }
+  });
+});

--- a/src/infer/__tests__/unify.test.ts
+++ b/src/infer/__tests__/unify.test.ts
@@ -26,10 +26,10 @@ describe("unify", () => {
 
     let constraints: Constraint[] = [
       [t1, b.tFun([b.tParam("", t5)], t4)], // function call
-      [t5, builtins.tNumber],
-      [t4, builtins.tBoolean],
-      [t6, builtins.tNumber],
-      [t7, builtins.tNumber],
+      [t5, builtins.tNumber()],
+      [t4, builtins.tBoolean()],
+      [t6, builtins.tNumber()],
+      [t7, builtins.tNumber()],
       [t6, t3],
       [t7, t3],
       [t2, b.tFun([b.tParam("", t1)], t3)], // function definition

--- a/src/infer/__tests__/util.test.ts
+++ b/src/infer/__tests__/util.test.ts
@@ -40,8 +40,8 @@ describe("equal", () => {
     });
 
     test("foo<number>", () => {
-      const x = b.tCon("foo", [builtins.tNumber]);
-      const y = b.tCon("foo", [builtins.tNumber]);
+      const x = b.tCon("foo", [builtins.tNumber()]);
+      const y = b.tCon("foo", [builtins.tNumber()]);
       expect(equal(x, y)).toBe(true);
     });
 
@@ -53,8 +53,8 @@ describe("equal", () => {
     });
 
     test("foo<number> != foo<string>", () => {
-      const x = b.tCon("foo", [builtins.tNumber]);
-      const y = b.tCon("foo", [builtins.tString]);
+      const x = b.tCon("foo", [builtins.tNumber()]);
+      const y = b.tCon("foo", [builtins.tString()]);
       expect(equal(x, y)).toBe(false);
     });
 
@@ -68,79 +68,88 @@ describe("equal", () => {
 
   describe("function types", () => {
     test("() => number", () => {
-      const f1 = b.tFun([], builtins.tNumber);
-      const f2 = b.tFun([], builtins.tNumber);
+      const f1 = b.tFun([], builtins.tNumber());
+      const f2 = b.tFun([], builtins.tNumber());
       expect(equal(f1, f2)).toBe(true);
     });
 
     test("(number, string) => void", () => {
       const f1 = b.tFun(
-        [b.tParam("", builtins.tNumber), b.tParam("", builtins.tString)],
-        builtins.tUndefined
+        [b.tParam("", builtins.tNumber()), b.tParam("", builtins.tString())],
+        builtins.tUndefined()
       );
       const f2 = b.tFun(
-        [b.tParam("", builtins.tNumber), b.tParam("", builtins.tString)],
-        builtins.tUndefined
+        [b.tParam("", builtins.tNumber()), b.tParam("", builtins.tString())],
+        builtins.tUndefined()
       );
       expect(equal(f1, f2)).toBe(true);
     });
 
     test("differences in param names are ignored", () => {
       const f1 = b.tFun(
-        [b.tParam("foo", builtins.tNumber), b.tParam("bar", builtins.tString)],
-        builtins.tUndefined
+        [
+          b.tParam("foo", builtins.tNumber()),
+          b.tParam("bar", builtins.tString()),
+        ],
+        builtins.tUndefined()
       );
       const f2 = b.tFun(
-        [b.tParam("x", builtins.tNumber), b.tParam("y", builtins.tString)],
-        builtins.tUndefined
+        [b.tParam("x", builtins.tNumber()), b.tParam("y", builtins.tString())],
+        builtins.tUndefined()
       );
       expect(equal(f1, f2)).toBe(true);
     });
 
     test("different number of params", () => {
       const f1 = b.tFun(
-        [b.tParam("", builtins.tNumber), b.tParam("", builtins.tString)],
-        builtins.tUndefined
+        [b.tParam("", builtins.tNumber()), b.tParam("", builtins.tString())],
+        builtins.tUndefined()
       );
-      const f2 = b.tFun([b.tParam("", builtins.tNumber)], builtins.tUndefined);
+      const f2 = b.tFun(
+        [b.tParam("", builtins.tNumber())],
+        builtins.tUndefined()
+      );
       expect(equal(f1, f2)).toBe(false);
     });
 
     test("different return types", () => {
       const f1 = b.tFun(
-        [b.tParam("", builtins.tNumber), b.tParam("", builtins.tString)],
-        builtins.tUndefined
+        [b.tParam("", builtins.tNumber()), b.tParam("", builtins.tString())],
+        builtins.tUndefined()
       );
       const f2 = b.tFun(
-        [b.tParam("", builtins.tNumber), b.tParam("", builtins.tString)],
-        builtins.tBoolean
+        [b.tParam("", builtins.tNumber()), b.tParam("", builtins.tString())],
+        builtins.tBoolean()
       );
       expect(equal(f1, f2)).toBe(false);
     });
 
     test("different param types", () => {
       const f1 = b.tFun(
-        [b.tParam("", builtins.tNumber), b.tParam("", builtins.tString)],
-        builtins.tUndefined
+        [b.tParam("", builtins.tNumber()), b.tParam("", builtins.tString())],
+        builtins.tUndefined()
       );
       const f2 = b.tFun(
-        [b.tParam("", builtins.tNumber), b.tParam("", builtins.tBoolean)],
-        builtins.tUndefined
+        [b.tParam("", builtins.tNumber()), b.tParam("", builtins.tBoolean())],
+        builtins.tUndefined()
       );
       expect(equal(f1, f2)).toBe(false);
     });
 
     test("optional params are the same as `T | undefined`", () => {
       const f1 = b.tFun(
-        [b.tParam("", builtins.tNumber), b.tParam("", builtins.tString, true)],
-        builtins.tUndefined
+        [
+          b.tParam("", builtins.tNumber()),
+          b.tParam("", builtins.tString(), true),
+        ],
+        builtins.tUndefined()
       );
       const f2 = b.tFun(
         [
-          b.tParam("", builtins.tNumber),
-          b.tParam("", b.tUnion(builtins.tString, builtins.tUndefined)),
+          b.tParam("", builtins.tNumber()),
+          b.tParam("", b.tUnion(builtins.tString(), builtins.tUndefined())),
         ],
-        builtins.tUndefined
+        builtins.tUndefined()
       );
       expect(equal(f1, f2)).toBe(true);
     });
@@ -149,60 +158,60 @@ describe("equal", () => {
   describe("Record types", () => {
     test("same", () => {
       const r1 = b.tRec(
-        b.tProp("x", builtins.tNumber),
-        b.tProp("y", builtins.tString, true)
+        b.tProp("x", builtins.tNumber()),
+        b.tProp("y", builtins.tString(), true)
       );
       const r2 = b.tRec(
-        b.tProp("x", builtins.tNumber),
-        b.tProp("y", builtins.tString, true)
+        b.tProp("x", builtins.tNumber()),
+        b.tProp("y", builtins.tString(), true)
       );
       expect(equal(r1, r2)).toBe(true);
     });
 
     test("different optionality", () => {
       const r1 = b.tRec(
-        b.tProp("x", builtins.tNumber),
-        b.tProp("y", builtins.tString, true)
+        b.tProp("x", builtins.tNumber()),
+        b.tProp("y", builtins.tString(), true)
       );
       const r2 = b.tRec(
-        b.tProp("x", builtins.tNumber),
-        b.tProp("y", builtins.tString)
+        b.tProp("x", builtins.tNumber()),
+        b.tProp("y", builtins.tString())
       );
       expect(equal(r1, r2)).toBe(false);
     });
 
     test("different property type", () => {
       const r1 = b.tRec(
-        b.tProp("x", builtins.tNumber),
-        b.tProp("y", builtins.tString, true)
+        b.tProp("x", builtins.tNumber()),
+        b.tProp("y", builtins.tString(), true)
       );
       const r2 = b.tRec(
-        b.tProp("x", builtins.tNumber),
-        b.tProp("y", builtins.tBoolean, true)
+        b.tProp("x", builtins.tNumber()),
+        b.tProp("y", builtins.tBoolean(), true)
       );
       expect(equal(r1, r2)).toBe(false);
     });
 
     test("different property name", () => {
       const r1 = b.tRec(
-        b.tProp("x", builtins.tNumber),
-        b.tProp("y", builtins.tString, true)
+        b.tProp("x", builtins.tNumber()),
+        b.tProp("y", builtins.tString(), true)
       );
       const r2 = b.tRec(
-        b.tProp("x", builtins.tNumber),
-        b.tProp("z", builtins.tString, true)
+        b.tProp("x", builtins.tNumber()),
+        b.tProp("z", builtins.tString(), true)
       );
       expect(equal(r1, r2)).toBe(false);
     });
 
     test("optional is the same a `T | undefined`", () => {
       const r1 = b.tRec(
-        b.tProp("x", builtins.tNumber),
-        b.tProp("y", b.tUnion(builtins.tString, builtins.tUndefined))
+        b.tProp("x", builtins.tNumber()),
+        b.tProp("y", b.tUnion(builtins.tString(), builtins.tUndefined()))
       );
       const r2 = b.tRec(
-        b.tProp("x", builtins.tNumber),
-        b.tProp("y", builtins.tString, true)
+        b.tProp("x", builtins.tNumber()),
+        b.tProp("y", builtins.tString(), true)
       );
       // All tests should test both others to ensure that equal is
       // commutative
@@ -213,15 +222,15 @@ describe("equal", () => {
 
   describe("type constructors", () => {
     test("same", () => {
-      const t1 = b.tCon("Foo", [builtins.tNumber]);
-      const t2 = b.tCon("Foo", [builtins.tNumber]);
+      const t1 = b.tCon("Foo", [builtins.tNumber()]);
+      const t2 = b.tCon("Foo", [builtins.tNumber()]);
       expect(equal(t1, t2)).toBe(true);
     });
   });
 
   test("different type of type", () => {
-    const t1 = builtins.tNumber;
-    const t2 = b.tFun([], builtins.tNumber);
+    const t1 = builtins.tNumber();
+    const t2 = b.tFun([], builtins.tNumber());
     expect(equal(t1, t2)).toBe(false);
   });
 });
@@ -234,27 +243,27 @@ describe("isSubtypeOf", () => {
     });
 
     test("5 is a subtype of number", () => {
-      const result = isSubtypeOf(b.tNum(5), builtins.tNumber);
+      const result = isSubtypeOf(b.tNum(5), builtins.tNumber());
       expect(result).toBe(true);
     });
 
     test("5 is not a subtype of string", () => {
-      const result = isSubtypeOf(b.tNum(5), builtins.tString);
+      const result = isSubtypeOf(b.tNum(5), builtins.tString());
       expect(result).toBe(false);
     });
 
     test("true is a subtype of boolean", () => {
-      const result = isSubtypeOf(b.tBool(true), builtins.tBoolean);
+      const result = isSubtypeOf(b.tBool(true), builtins.tBoolean());
       expect(result).toBe(true);
     });
 
     test("false is a subtype of boolean", () => {
-      const result = isSubtypeOf(b.tBool(false), builtins.tBoolean);
+      const result = isSubtypeOf(b.tBool(false), builtins.tBoolean());
       expect(result).toBe(true);
     });
 
     test("'hello' is a subtype of string", () => {
-      const result = isSubtypeOf(b.tStr("hello"), builtins.tString);
+      const result = isSubtypeOf(b.tStr("hello"), builtins.tString());
       expect(result).toBe(true);
     });
 
@@ -274,7 +283,7 @@ describe("isSubtypeOf", () => {
 
     test("5 is a subtype of number | string", () => {
       const t1 = b.tNum(5);
-      const t2 = b.tUnion(builtins.tNumber, builtins.tString);
+      const t2 = b.tUnion(builtins.tNumber(), builtins.tString());
       const result = isSubtypeOf(t1, t2);
       expect(result).toBe(true);
     });
@@ -290,12 +299,12 @@ describe("isSubtypeOf", () => {
   describe("record subtyping", () => {
     test("same", () => {
       const r1 = b.tRec(
-        b.tProp("x", builtins.tNumber),
-        b.tProp("y", builtins.tString, true)
+        b.tProp("x", builtins.tNumber()),
+        b.tProp("y", builtins.tString(), true)
       );
       const r2 = b.tRec(
-        b.tProp("x", builtins.tNumber),
-        b.tProp("y", builtins.tString, true)
+        b.tProp("x", builtins.tNumber()),
+        b.tProp("y", builtins.tString(), true)
       );
       const result = isSubtypeOf(r1, r2);
       expect(result).toBe(true);
@@ -303,13 +312,13 @@ describe("isSubtypeOf", () => {
 
     test("the subtype can have extra fields", () => {
       const r1 = b.tRec(
-        b.tProp("x", builtins.tNumber),
-        b.tProp("y", builtins.tString, true),
-        b.tProp("z", builtins.tBoolean)
+        b.tProp("x", builtins.tNumber()),
+        b.tProp("y", builtins.tString(), true),
+        b.tProp("z", builtins.tBoolean())
       );
       const r2 = b.tRec(
-        b.tProp("x", builtins.tNumber),
-        b.tProp("y", builtins.tString, true)
+        b.tProp("x", builtins.tNumber()),
+        b.tProp("y", builtins.tString(), true)
       );
       const result = isSubtypeOf(r1, r2);
       expect(result).toBe(true);
@@ -317,12 +326,12 @@ describe("isSubtypeOf", () => {
 
     test("optional property isn't a subtype of a non-optional one", () => {
       const r1 = b.tRec(
-        b.tProp("x", builtins.tNumber),
-        b.tProp("y", builtins.tString, true)
+        b.tProp("x", builtins.tNumber()),
+        b.tProp("y", builtins.tString(), true)
       );
       const r2 = b.tRec(
-        b.tProp("x", builtins.tNumber),
-        b.tProp("y", builtins.tString)
+        b.tProp("x", builtins.tNumber()),
+        b.tProp("y", builtins.tString())
       );
       const result = isSubtypeOf(r1, r2);
       expect(result).toBe(false);
@@ -330,22 +339,22 @@ describe("isSubtypeOf", () => {
 
     test("non-optional property is a subtype of a optional one", () => {
       const r1 = b.tRec(
-        b.tProp("x", builtins.tNumber),
-        b.tProp("y", builtins.tString)
+        b.tProp("x", builtins.tNumber()),
+        b.tProp("y", builtins.tString())
       );
       const r2 = b.tRec(
-        b.tProp("x", builtins.tNumber),
-        b.tProp("y", builtins.tString, true)
+        b.tProp("x", builtins.tNumber()),
+        b.tProp("y", builtins.tString(), true)
       );
       const result = isSubtypeOf(r1, r2);
       expect(result).toBe(true);
     });
 
     test("the subtype can't have fewer fields", () => {
-      const r1 = b.tRec(b.tProp("x", builtins.tNumber));
+      const r1 = b.tRec(b.tProp("x", builtins.tNumber()));
       const r2 = b.tRec(
-        b.tProp("x", builtins.tNumber),
-        b.tProp("y", builtins.tString, true)
+        b.tProp("x", builtins.tNumber()),
+        b.tProp("y", builtins.tString(), true)
       );
       const result = isSubtypeOf(r1, r2);
       expect(result).toBe(false);
@@ -354,18 +363,18 @@ describe("isSubtypeOf", () => {
 
   describe("tuple type", () => {
     test("same", () => {
-      const t1 = b.tTuple(builtins.tNumber, builtins.tString);
-      const t2 = b.tTuple(builtins.tNumber, builtins.tString);
+      const t1 = b.tTuple(builtins.tNumber(), builtins.tString());
+      const t2 = b.tTuple(builtins.tNumber(), builtins.tString());
 
       const result = isSubtypeOf(t1, t2);
 
       expect(result).toBe(true);
     });
 
-    test("each elem is a subtype", () => {
+    test.only("each elem is a subtype", () => {
       // [5, "hello"] is a subtype of [number, string]
       const t1 = b.tTuple(b.tNum(5), b.tStr("hello"));
-      const t2 = b.tTuple(builtins.tNumber, builtins.tString);
+      const t2 = b.tTuple(builtins.tNumber(), builtins.tString());
 
       const result = isSubtypeOf(t1, t2);
 
@@ -375,7 +384,7 @@ describe("isSubtypeOf", () => {
     test("each elem is a subtype Array's type argument", () => {
       // [5, 10] is a subtype of Array<number>
       const t1 = b.tTuple(b.tNum(5), b.tNum(10));
-      const t2 = builtins.tArray(builtins.tNumber);
+      const t2 = builtins.tArray(builtins.tNumber());
 
       const result = isSubtypeOf(t1, t2);
 
@@ -386,12 +395,12 @@ describe("isSubtypeOf", () => {
   describe("function sub-typing", () => {
     test("same", () => {
       const f1 = b.tFun(
-        [b.tParam("", builtins.tNumber), b.tParam("", builtins.tString)],
-        builtins.tBoolean
+        [b.tParam("", builtins.tNumber()), b.tParam("", builtins.tString())],
+        builtins.tBoolean()
       );
       const f2 = b.tFun(
-        [b.tParam("", builtins.tNumber), b.tParam("", builtins.tString)],
-        builtins.tBoolean
+        [b.tParam("", builtins.tNumber()), b.tParam("", builtins.tString())],
+        builtins.tBoolean()
       );
 
       const result = isSubtypeOf(f1, f2);
@@ -400,12 +409,12 @@ describe("isSubtypeOf", () => {
 
     test("return type is a subtype", () => {
       const f1 = b.tFun(
-        [b.tParam("", builtins.tNumber), b.tParam("", builtins.tString)],
+        [b.tParam("", builtins.tNumber()), b.tParam("", builtins.tString())],
         builtins.tTrue
       );
       const f2 = b.tFun(
-        [b.tParam("", builtins.tNumber), b.tParam("", builtins.tString)],
-        builtins.tBoolean
+        [b.tParam("", builtins.tNumber()), b.tParam("", builtins.tString())],
+        builtins.tBoolean()
       );
 
       const result = isSubtypeOf(f1, f2);
@@ -414,11 +423,11 @@ describe("isSubtypeOf", () => {
 
     test("not a subtype if return type is a supertype", () => {
       const f1 = b.tFun(
-        [b.tParam("", builtins.tNumber), b.tParam("", builtins.tString)],
-        builtins.tBoolean
+        [b.tParam("", builtins.tNumber()), b.tParam("", builtins.tString())],
+        builtins.tBoolean()
       );
       const f2 = b.tFun(
-        [b.tParam("", builtins.tNumber), b.tParam("", builtins.tString)],
+        [b.tParam("", builtins.tNumber()), b.tParam("", builtins.tString())],
         builtins.tTrue
       );
 
@@ -429,13 +438,13 @@ describe("isSubtypeOf", () => {
     test("is a subtype if arg type is a supertype", () => {
       // f1 = (x: number, y: string) => boolean
       const f1 = b.tFun(
-        [b.tParam("", builtins.tNumber), b.tParam("", builtins.tString)],
-        builtins.tBoolean
+        [b.tParam("", builtins.tNumber()), b.tParam("", builtins.tString())],
+        builtins.tBoolean()
       );
       // f2 = (x: 5, y: string) => boolean
       const f2 = b.tFun(
-        [b.tParam("", b.tNum(5)), b.tParam("", builtins.tString)],
-        builtins.tBoolean
+        [b.tParam("", b.tNum(5)), b.tParam("", builtins.tString())],
+        builtins.tBoolean()
       );
 
       // f2(5, "hello") is valid and so is f1(5, "hello") because f1 accepts
@@ -447,13 +456,13 @@ describe("isSubtypeOf", () => {
     test("is not a subtype if arg type is a subtype", () => {
       // f1 = (x: 5, y: string) => boolean
       const f1 = b.tFun(
-        [b.tParam("", b.tNum(5)), b.tParam("", builtins.tString)],
-        builtins.tBoolean
+        [b.tParam("", b.tNum(5)), b.tParam("", builtins.tString())],
+        builtins.tBoolean()
       );
       // f2 = (x: number, y: string) => boolean
       const f2 = b.tFun(
-        [b.tParam("", builtins.tNumber), b.tParam("", builtins.tString)],
-        builtins.tBoolean
+        [b.tParam("", builtins.tNumber()), b.tParam("", builtins.tString())],
+        builtins.tBoolean()
       );
 
       // f2(10, "hello") is valid, but f1(10, "hello") is not
@@ -462,10 +471,13 @@ describe("isSubtypeOf", () => {
     });
 
     test("having fewer params is a subtype", () => {
-      const f1 = b.tFun([b.tParam("", builtins.tNumber)], builtins.tBoolean);
+      const f1 = b.tFun(
+        [b.tParam("", builtins.tNumber())],
+        builtins.tBoolean()
+      );
       const f2 = b.tFun(
-        [b.tParam("", builtins.tNumber), b.tParam("", builtins.tString)],
-        builtins.tBoolean
+        [b.tParam("", builtins.tNumber()), b.tParam("", builtins.tString())],
+        builtins.tBoolean()
       );
 
       const result = isSubtypeOf(f1, f2);
@@ -475,15 +487,15 @@ describe("isSubtypeOf", () => {
     test("having more params is not a subtype", () => {
       const f1 = b.tFun(
         [
-          b.tParam("", builtins.tNumber),
-          b.tParam("", builtins.tString),
-          b.tParam("", builtins.tNumber),
+          b.tParam("", builtins.tNumber()),
+          b.tParam("", builtins.tString()),
+          b.tParam("", builtins.tNumber()),
         ],
-        builtins.tBoolean
+        builtins.tBoolean()
       );
       const f2 = b.tFun(
-        [b.tParam("", builtins.tNumber), b.tParam("", builtins.tString)],
-        builtins.tBoolean
+        [b.tParam("", builtins.tNumber()), b.tParam("", builtins.tString())],
+        builtins.tBoolean()
       );
 
       const result = isSubtypeOf(f1, f2);
@@ -495,15 +507,15 @@ describe("isSubtypeOf", () => {
       // extra params.
       const f1 = b.tFun(
         [
-          b.tParam("", builtins.tNumber),
-          b.tParam("", builtins.tString),
-          b.tParam("", builtins.tBoolean, true),
+          b.tParam("", builtins.tNumber()),
+          b.tParam("", builtins.tString()),
+          b.tParam("", builtins.tBoolean(), true),
         ],
-        builtins.tBoolean
+        builtins.tBoolean()
       );
       const f2 = b.tFun(
-        [b.tParam("", builtins.tNumber), b.tParam("", builtins.tString)],
-        builtins.tBoolean
+        [b.tParam("", builtins.tNumber()), b.tParam("", builtins.tString())],
+        builtins.tBoolean()
       );
 
       const result = isSubtypeOf(f1, f2);
@@ -527,21 +539,21 @@ describe("isSubtypeOf", () => {
   describe("type constructor", () => {
     test("subtype if type args are subtypes", () => {
       let c1 = b.tCon("Foo", [b.tNum(5)]);
-      let c2 = b.tCon("Foo", [builtins.tNumber]);
+      let c2 = b.tCon("Foo", [builtins.tNumber()]);
 
       expect(isSubtypeOf(c1, c2)).toBe(true);
     });
 
     test("not a subtype if type args are not subtypes", () => {
-      let c1 = b.tCon("Foo", [builtins.tString]);
-      let c2 = b.tCon("Foo", [builtins.tNumber]);
+      let c1 = b.tCon("Foo", [builtins.tString()]);
+      let c2 = b.tCon("Foo", [builtins.tNumber()]);
 
       expect(isSubtypeOf(c1, c2)).toBe(false);
     });
 
     test("not a subtype if type if different number of type args", () => {
-      let c1 = b.tCon("Foo", [builtins.tNumber]);
-      let c2 = b.tCon("Foo", [builtins.tNumber, builtins.tString]);
+      let c1 = b.tCon("Foo", [builtins.tNumber()]);
+      let c2 = b.tCon("Foo", [builtins.tNumber(), builtins.tString()]);
 
       expect(isSubtypeOf(c1, c2)).toBe(false);
     });
@@ -550,7 +562,7 @@ describe("isSubtypeOf", () => {
 
 describe("flatten", () => {
   test("3 | 5 | number -> number", () => {
-    const t = b.tUnion(b.tNum(3), b.tNum(5), builtins.tNumber);
+    const t = b.tUnion(b.tNum(3), b.tNum(5), builtins.tNumber());
 
     const result = flatten(t);
 
@@ -558,7 +570,7 @@ describe("flatten", () => {
   });
 
   test("number | 5 -> number", () => {
-    const t = b.tUnion(builtins.tNumber, b.tNum(5));
+    const t = b.tUnion(builtins.tNumber(), b.tNum(5));
 
     const result = flatten(t);
 
@@ -566,7 +578,7 @@ describe("flatten", () => {
   });
 
   test("5 | (10 | number) -> number", () => {
-    const t = b.tUnion(b.tNum(5), b.tUnion(b.tNum(5), builtins.tNumber));
+    const t = b.tUnion(b.tNum(5), b.tUnion(b.tNum(5), builtins.tNumber()));
 
     const result = flatten(t);
 

--- a/src/infer/analyze.ts
+++ b/src/infer/analyze.ts
@@ -43,13 +43,6 @@ export const annotate = (e: Expr, env: Environment): AExpr => {
       if (varType) {
         return { tag: "AVar", name: e.name, ann: varType };
       } else {
-        console.log(`e.name = ${e.name}`);
-        console.log(`env = `, env);
-        for (const key of env.keys()) {
-          console.log(`key = ${key}, e.name = ${e.name}, ${key === e.name}`);
-          console.log(typeof key);
-          console.log(typeof e.name);
-        }
         throw new Error(`variable "${e.name}" not defined`);
       }
     }

--- a/src/infer/builtins.ts
+++ b/src/infer/builtins.ts
@@ -4,10 +4,10 @@ import * as t from './types';
 export const tTrue = b.tBool(true); 
 export const tFalse = b.tBool(false);
 
-export const tUndefined = b.tCon('undefined');
-export const tNumber = b.tCon('number');
-export const tBoolean = b.tCon('boolean');
-export const tString = b.tCon('string');
+export const tUndefined = () => b.tCon('undefined');
+export const tNumber = () => b.tCon('number');
+export const tBoolean = () => b.tCon('boolean');
+export const tString = () => b.tCon('string');
 
 // TODO: figure out how to model methods and getters
 // .map(), .forEach(), .length

--- a/src/infer/util.ts
+++ b/src/infer/util.ts
@@ -29,7 +29,7 @@ export const flatten = (union: t.TUnion): t.Type => {
 
 // TODO: How do report errors if we wrap types like this to do comparisons?
 const makeOptional = (x: t.Type): t.Type => {
-  return flatten(b.tUnion(x, builtins.tUndefined));
+  return flatten(b.tUnion(x, builtins.tUndefined()));
 };
 
 export const getPropType = (x: t.TProp): t.Type =>
@@ -108,11 +108,11 @@ export const isSubtypeOf = (x: t.Type, y: t.Type): boolean => {
       const l = x.literal;
       switch (l.t) {
         case "LBool":
-          return equal(y, builtins.tBoolean);
+          return y.t === "TCon" && y.name === "boolean";
         case "LNum":
-          return equal(y, builtins.tNumber);
+          return y.t === "TCon" && y.name === "number";
         case "LStr":
-          return equal(y, builtins.tString);
+          return y.t === "TCon" && y.name === "string";
       }
     }
     case "TCon": {
@@ -186,7 +186,7 @@ export const isSubtypeOf = (x: t.Type, y: t.Type): boolean => {
           // is a subtype the param).
           const remainingParamTypes = x.paramTypes.slice(y.paramTypes.length);
           const isOptional = (p: t.TParam): boolean =>
-            isSubtypeOf(builtins.tUndefined, getParamType(p));
+            isSubtypeOf(builtins.tUndefined(), getParamType(p));
           if (!remainingParamTypes.every(isOptional)) {
             return false;
           }


### PR DESCRIPTION
This ports a couple of tests from `hindley-milner/src/__tests__/infer.tests.ts` and fixes an issue with how we were doing substitution.  The fix involves now creating new `TCon` instances in `substitute()`, instead mutating their `.widened` property directly.  In a future PR we'll try replacing this approach by allow `TCon` and other types to be substituted instead of just `TVar`s.