### PR TITLE
Extend substitute() to handle more than just TVars

### DIFF
--- a/src/infer/__tests__/analyze.test.ts
+++ b/src/infer/__tests__/analyze.test.ts
@@ -4,6 +4,7 @@ import { annotate, collect } from "../analyze";
 import { unify, applySubst, Subst } from "../unify";
 import * as t from "../types";
 import { print } from "../printer";
+import * as core from "../core";
 
 const printSubstitutions = (subs: Subst[]): string[] => {
   const varNames = {};
@@ -15,6 +16,11 @@ const printSubstitutions = (subs: Subst[]): string[] => {
 };
 
 describe("annotate", () => {
+  beforeEach(() => {
+    let id = 0;
+    jest.spyOn(core, "getId").mockImplementation(() => id++);
+  });
+
   test("let f = (x) => x in f(5)", () => {
     const ast: Expr = {
       tag: "Let",
@@ -36,7 +42,13 @@ describe("annotate", () => {
     const constraints = collect(annotatedAst);
     const substitutions = unify(constraints);
     const result = printSubstitutions(substitutions);
-    expect(result).toEqual(["t1 ≡ (x: 5) => 5", "t0 ≡ 5", "t2 ≡ 5"]);
+    expect(result).toMatchInlineSnapshot(`
+Array [
+  "t3 ≡ (x: 5) => 5",
+  "t0 ≡ 5",
+  "t5 ≡ 5",
+]
+`);
   });
 
   test("((x) => x)(5)", () => {
@@ -55,6 +67,10 @@ describe("annotate", () => {
     const constraints = collect(annotatedAst);
     const substitutions = unify(constraints);
     const result = printSubstitutions(substitutions);
-    expect(result).toEqual(["t3 ≡ 5"]);
+    expect(result).toMatchInlineSnapshot(`
+Array [
+  "t0 ≡ 5",
+]
+`);
   });
 });

--- a/src/infer/__tests__/unify.test.ts
+++ b/src/infer/__tests__/unify.test.ts
@@ -2,6 +2,7 @@ import * as b from "../builders";
 import * as builtins from "../builtins";
 import { print } from "../printer";
 import { applySubst, unify, Constraint, Subst } from "../unify";
+import * as core from "../core";
 
 const printSubstitutions = (subs: Subst[]): string[] => {
   const varNames = {};
@@ -13,6 +14,11 @@ const printSubstitutions = (subs: Subst[]): string[] => {
 };
 
 describe("unify", () => {
+  beforeEach(() => {
+    let id = 0;
+    jest.spyOn(core, "getId").mockImplementation(() => id++);
+  });
+
   test("simple example", () => {
     const t0 = b.tVar(); // ignore this, we create it so that the ids line up
 

--- a/src/infer/__tests__/util.test.ts
+++ b/src/infer/__tests__/util.test.ts
@@ -558,6 +558,12 @@ describe("isSubtypeOf", () => {
       expect(isSubtypeOf(c1, c2)).toBe(false);
     });
   });
+
+  describe("union type", () => {
+    test.todo("union of number literals is subtype of number");
+    test.todo("union of string literals is subtype of string");
+    test.todo("union of function types is subtype is subtype of function if each element type is a subtype of the function");
+  });
 });
 
 describe("flatten", () => {

--- a/src/infer/__tests__/util.test.ts
+++ b/src/infer/__tests__/util.test.ts
@@ -371,7 +371,7 @@ describe("isSubtypeOf", () => {
       expect(result).toBe(true);
     });
 
-    test.only("each elem is a subtype", () => {
+    test("each elem is a subtype", () => {
       // [5, "hello"] is a subtype of [number, string]
       const t1 = b.tTuple(b.tNum(5), b.tStr("hello"));
       const t2 = b.tTuple(builtins.tNumber(), builtins.tString());
@@ -595,8 +595,7 @@ describe("flatten", () => {
     expect(print(result)).toEqual("a | b | c | d");
   });
 
-  // TODO: flatten needs to be updated to handle duplicates in the union
-  test.skip("(a | b) | (b | c) -> a | b | c", () => {
+  test("(a | b) | (b | c) -> a | b | c", () => {
     const at = b.tVar();
     const bt = b.tVar();
     const ct = b.tVar();

--- a/src/infer/builders.ts
+++ b/src/infer/builders.ts
@@ -14,7 +14,7 @@ const lStr = (value: string): t.LStr => {
 };
 
 const tLit = (literal: t.Literal): t.TLiteral => {
-  return { t: "TLit", literal };
+  return { t: "TLit", id: getId(), literal };
 };
 
 export const tBool = (value: boolean): t.TLiteral => {
@@ -37,18 +37,18 @@ export const tCon = (
   name: string,
   typeArgs: readonly t.Type[] = []
 ): t.TCon => {
-  return { t: "TCon", name, typeArgs };
+  return { t: "TCon", id: getId(), name, typeArgs };
 };
 
 export const tFun = (
   paramTypes: readonly t.TParam[],
   retType: t.Type
 ): t.TFun => {
-  return { t: "TFun", paramTypes, retType };
+  return { t: "TFun", id: getId(), paramTypes, retType };
 };
 
 export const tRec = (...properties: readonly t.TProp[]): t.TRec => {
-  return { t: "TRec", properties };
+  return { t: "TRec", id: getId(), properties };
 };
 
 export const tProp = (
@@ -56,7 +56,7 @@ export const tProp = (
   type: t.Type,
   optional = false // TODO: make this an enum instead
 ): t.TProp => {
-  return { t: "TProp", name, type, optional };
+  return { t: "TProp", id: getId(), name, type, optional };
 };
 
 export const tParam = (
@@ -64,13 +64,13 @@ export const tParam = (
   type: t.Type,
   optional = false
 ): t.TParam => {
-  return { t: "TParam", name, type, optional };
+  return { t: "TParam", id: getId(), name, type, optional };
 };
 
 export const tTuple = (...types: readonly t.Type[]): t.TTuple => {
-  return { t: "TTuple", types };
+  return { t: "TTuple", id: getId(), types };
 };
 
 export const tUnion = (...types: readonly t.Type[]): t.TUnion => {
-  return { t: "TUnion", types };
+  return { t: "TUnion", id: getId(), types };
 };

--- a/src/infer/printer.ts
+++ b/src/infer/printer.ts
@@ -14,7 +14,6 @@ export const print = (
   let nextName: string = String.fromCharCode(nextNameCharCode);
 
   const _print = (t: Type): string => {
-    t = t.widened || t;
     switch (t.t) {
       case "TLit": {
         const l = t.literal;

--- a/src/infer/types.ts
+++ b/src/infer/types.ts
@@ -35,8 +35,8 @@ export type LStr = {
 export type Literal = LBool | LNum | LStr;
 
 type TCommon = {
-  frozen?: boolean, // if true, can unify with non-frozen sub-types
-  widened?: Type, // if set, unifyTypes should use this instead
+  id: number;
+  frozen?: boolean; // if true, can unify with non-frozen sub-types
 };
 
 export type TLiteral = TCommon & {
@@ -48,7 +48,6 @@ export type TLiteral = TCommon & {
 // TODO: constraints on type variables
 export type TVar = TCommon & {
   t: "TVar";
-  id: number;
 };
 
 // TODO: default + optional type args

--- a/src/infer/unify.ts
+++ b/src/infer/unify.ts
@@ -70,11 +70,7 @@ const unifyTypes = (a: t.Type, b: t.Type): Subst[] => {
     }
 
     if (!a.frozen && !b.frozen) {
-      const union = flatten(build.tUnion(a, b));
-      return [
-        [a.id, union],
-        [b.id, union],
-      ];
+      return widen(a, b);
     }
 
     throw new Error(`mismatched types: ${a.t} != ${b.t}`);

--- a/src/infer/util.ts
+++ b/src/infer/util.ts
@@ -17,14 +17,22 @@ export const flatten = (union: t.TUnion): t.Type => {
   // TODO: remove duplicates
   // TODO: rewrite this using immutable.js so we're not so memory inefficient
   const uniqueTypes: t.Type[] = [];
-  types.forEach((t, i) => {
-    const remainingTypes = [...types.slice(0, i), ...types.slice(i + 1)];
+  for (const type of types) {
+    if (!uniqueTypes.some(uniqueType => equal(uniqueType, type))) {
+      uniqueTypes.push(type);
+    }
+  }
+
+  const mergedTypes: t.Type[] = [];
+  uniqueTypes.forEach((t, i) => {
+    const remainingTypes = [...uniqueTypes.slice(0, i), ...uniqueTypes.slice(i + 1)];
     if (!remainingTypes.some((rt) => isSubtypeOf(t, rt))) {
-      uniqueTypes.push(t);
+      mergedTypes.push(t);
     }
   });
+ 
   // TODO: assert uniqueTypes.length > 0
-  return uniqueTypes.length === 1 ? uniqueTypes[0] : b.tUnion(...uniqueTypes);
+  return mergedTypes.length === 1 ? mergedTypes[0] : b.tUnion(...mergedTypes);
 };
 
 // TODO: How do report errors if we wrap types like this to do comparisons?


### PR DESCRIPTION
The old way of widening types involved mutating type objects.  This PR avoids that by giving each type object an `id` and allowing them to be substitute using the same mechanism as `TVar`s.