### PR TITLE
Port poly_constraint code from "Write you a Haskell" to TypeScript

### DIFF
--- a/write-you-a-haskell/README.md
+++ b/write-you-a-haskell/README.md
@@ -3,12 +3,7 @@
 - http://dev.stephendiehl.com/fun/index.html
 
 Start of simple by porting:
-https://github.com/sdiehl/write-you-a-haskell/blob/master/chapter7/poly/src/Infer.hs
-
-213 lines (not including helper files)
-
-Then update it to support let-polymorphism:
-https://github.com/sdiehl/write-you-a-haskell/blob/master/chapter7/poly_constraints/src/Infer.hs
+https://github.com/sdiehl/write-you-a-haskell/blob/master/chapter7/poly_constraints
 
 281 lines (not including helper files)
 

--- a/write-you-a-haskell/README.md
+++ b/write-you-a-haskell/README.md
@@ -1,0 +1,15 @@
+# Write You A Haskell
+
+- http://dev.stephendiehl.com/fun/index.html
+
+Start of simple by porting:
+https://github.com/sdiehl/write-you-a-haskell/blob/master/chapter7/poly/src/Infer.hs
+
+213 lines (not including helper files)
+
+Then update it to support let-polymorphism:
+https://github.com/sdiehl/write-you-a-haskell/blob/master/chapter7/poly_constraints/src/Infer.hs
+
+281 lines (not including helper files)
+
+After that, tackle thih.

--- a/write-you-a-haskell/src/__tests__/infer.test.ts
+++ b/write-you-a-haskell/src/__tests__/infer.test.ts
@@ -1,0 +1,256 @@
+import { Map } from "immutable";
+
+import { constraintsExpr, inferExpr } from "../infer";
+import { Expr } from "../syntax";
+import { Env, print } from "../type";
+
+type Binding = [string, Expr];
+
+const I: Binding = [
+  "I",
+  {
+    tag: "Lam",
+    arg: "x",
+    body: { tag: "Var", name: "x" },
+  },
+];
+
+const K: Binding = [
+  "K",
+  {
+    tag: "Lam",
+    arg: "x",
+    body: {
+      tag: "Lam",
+      arg: "y",
+      body: { tag: "Var", name: "x" },
+    },
+  },
+];
+
+// let S = (f) => (g) => (x) => f(x)(g(x))
+const S: Binding = [
+  "S",
+  {
+    tag: "Lam",
+    arg: "f",
+    body: {
+      tag: "Lam",
+      arg: "g",
+      body: {
+        tag: "Lam",
+        arg: "x",
+        body: {
+          tag: "App",
+          fn: {
+            tag: "App",
+            fn: { tag: "Var", name: "f" },
+            arg: { tag: "Var", name: "x" },
+          },
+          arg: {
+            tag: "App",
+            fn: { tag: "Var", name: "g" },
+            arg: { tag: "Var", name: "x" },
+          },
+        },
+      },
+    },
+  },
+];
+
+describe("inferExpr", () => {
+  describe("SKI cominbators", () => {
+
+    test("let I x = x", () => {
+      const env: Env = Map();
+      const result = inferExpr(env, I[1]);
+  
+      expect(print(result)).toEqual("forall a => (a -> a)");
+    });
+  
+    test("let K x y = x", () => {
+      const env: Env = Map();
+      const result = inferExpr(env, K[1]);
+  
+      expect(print(result)).toEqual("forall a, b => (a -> (b -> a))");
+    });
+  
+    test("let S f g x = f x (g x)", () => {
+      const env: Env = Map();
+      const result = inferExpr(env, S[1]);
+  
+      expect(print(result)).toEqual(
+        "forall a, b, c => ((a -> (b -> c)) -> ((a -> b) -> (a -> c)))"
+      );
+    });
+  
+    test("SKK", () => {
+      const S: Binding = [
+        "S",
+        {
+          tag: "Lam",
+          arg: "f",
+          body: {
+            tag: "Lam",
+            arg: "g",
+            body: {
+              tag: "Lam",
+              arg: "x",
+              body: {
+                tag: "App",
+                fn: {
+                  tag: "App",
+                  fn: { tag: "Var", name: "f" },
+                  arg: { tag: "Var", name: "x" },
+                },
+                arg: {
+                  tag: "App",
+                  fn: { tag: "Var", name: "g" },
+                  arg: { tag: "Var", name: "x" },
+                },
+              },
+            },
+          },
+        },
+      ];
+  
+      const skk: Binding = [
+        "skk",
+        {
+          tag: "App",
+          fn: {
+            tag: "App",
+            fn: { tag: "Var", name: "S" },
+            arg: { tag: "Var", name: "K" },
+          },
+          arg: { tag: "Var", name: "K" },
+        },
+      ];
+  
+      let env: Env = Map();
+      env = env.set(S[0], inferExpr(env, S[1]));
+      env = env.set(K[0], inferExpr(env, K[1]));
+      env = env.set(skk[0], inferExpr(env, skk[1]));
+  
+      const result = env.get("skk");
+      if (!result) {
+        throw new Error("skk is undefined");
+      }
+  
+      expect(print(result)).toEqual("forall a => (a -> a)");
+    });
+  
+    test("Mu f = f (fix f)", () => {
+      const K: Binding = [
+        "Mu",
+        {
+          tag: "Lam",
+          arg: "f",
+          body: {
+            tag: "App",
+            fn: { tag: "Var", name: "f" },
+            arg: { tag: "Fix", expr: { tag: "Var", name: "f" } },
+          },
+        },
+      ];
+  
+      const env: Env = Map();
+      const result = inferExpr(env, K[1]);
+  
+      expect(print(result)).toEqual("forall a => ((a -> a) -> a)");
+    });
+  });
+
+  describe("Functions", () => {
+    test.todo("let rec fib = (n) => ...");
+    test.todo("let const = (x) => (y) => x");
+    test.todo("let compose = (f) => (g) => (x) => f(g(x))");
+    test.todo("let twice = (f) => (x) => f(f(x))");
+    test.todo("let on = ...");
+    test.todo("let ap = ...");
+  });
+
+  describe("Let Polymorphism", () => {
+    test("let poly = I (I I) (I 3);", () => {
+      const poly: Binding = [
+        "poly",
+        {
+          tag: "App",
+          fn: {
+            tag: "App",
+            fn: I[1],
+            arg: I[1],
+          },
+          arg: {
+            tag: "App",
+            fn: I[1],
+            arg: {
+              tag: "Lit",
+              value: {
+                tag: "LInt",
+                value: 3,
+              }
+            }
+          }
+        }
+      ];
+
+      let env: Env = Map();
+      env = env.set(I[0], inferExpr(env, I[1]));
+      env = env.set(poly[0], inferExpr(env, poly[1]));
+  
+      const result = env.get("poly");
+      if (!result) {
+        throw new Error("poly is undefined");
+      }
+  
+      expect(print(result)).toEqual("Int");
+    });
+
+    test("let self = ((x) => x)((x) => x)", () => {
+      const self: Binding = [
+        "self",
+        {
+          tag: "App",
+          fn: {tag: "Lam", arg: "x", body: {tag: "Var", name: "x"}},
+          arg: {tag: "Lam", arg: "x", body: {tag: "Var", name: "x"}},
+        },
+      ];
+
+      const env: Env = Map();
+      const result = inferExpr(env, self[1]);
+
+      expect(print(result)).toEqual("forall a => (a -> a)");
+    });
+
+    test("let innerlet = (x) => (let y = (z) => z in y)", () => {
+      const innerlet: Binding = [
+        "innerlet",
+        {
+          tag: "Lam",
+          arg: "x",
+          body: {
+            tag: "Let",
+            name: "y",
+            value: {
+              tag: "Lam",
+              arg: "z",
+              body: {tag: "Var", name: "z"},
+            },
+            body: {tag: "Var", name: "y"},
+          }
+        }
+      ];
+
+      const env: Env = Map();
+      const result = inferExpr(env, innerlet[1]);
+
+      // the 'x' param is ignored
+      expect(print(result)).toEqual("forall a, b => (a -> (b -> b))");
+    });
+
+    // The expression tree for `let rec` appears to be the same as that
+    // for `let`.  
+    test.todo("let innerletrec = (x) => (let rec y = (z) => z in y)");
+  });  
+});

--- a/write-you-a-haskell/src/__tests__/infer.test.ts
+++ b/write-you-a-haskell/src/__tests__/infer.test.ts
@@ -71,20 +71,22 @@ const S: Binding = [
   ),
 ];
 
+const _const: Binding = ["const", lam("x", lam("y", _var("x")))];
+
 describe("inferExpr", () => {
   describe("SKI cominbators", () => {
     test("let I x = x", () => {
       const env: Env = Map();
       const result = inferExpr(env, I[1]);
 
-      expect(print(result)).toEqual("forall a => (a -> a)");
+      expect(print(result)).toEqual("forall a => a -> a");
     });
 
     test("let K x y = x", () => {
       const env: Env = Map();
       const result = inferExpr(env, K[1]);
 
-      expect(print(result)).toEqual("forall a, b => (a -> (b -> a))");
+      expect(print(result)).toEqual("forall a, b => a -> b -> a");
     });
 
     test("let S f g x = f x (g x)", () => {
@@ -92,7 +94,7 @@ describe("inferExpr", () => {
       const result = inferExpr(env, S[1]);
 
       expect(print(result)).toEqual(
-        "forall a, b, c => ((a -> (b -> c)) -> ((a -> b) -> (a -> c)))"
+        "forall a, b, c => (a -> b -> c) -> (a -> b) -> a -> c"
       );
     });
 
@@ -109,7 +111,7 @@ describe("inferExpr", () => {
         throw new Error("skk is undefined");
       }
 
-      expect(print(result)).toEqual("forall a => (a -> a)");
+      expect(print(result)).toEqual("forall a => a -> a");
     });
 
     test("Mu f = f (fix f)", () => {
@@ -118,27 +120,27 @@ describe("inferExpr", () => {
       const env: Env = Map();
       const result = inferExpr(env, Mu[1]);
 
-      expect(print(result)).toEqual("forall a => ((a -> a) -> a)");
+      expect(print(result)).toEqual("forall a => (a -> a) -> a");
     });
   });
 
   describe("Integer arithmetic", () => {
-    describe("let nsucc x = x + 1", () => {
+    test("let nsucc x = x + 1", () => {
       const nsucc: Binding = ["nsucc", lam("x", add(_var("x"), int(1)))];
 
       const env: Env = Map();
       const result = inferExpr(env, nsucc[1]);
 
-      expect(print(result)).toEqual("(Int -> Int)");
+      expect(print(result)).toEqual("Int -> Int");
     });
 
-    describe("let npred x = x - 1", () => {
+    test("let npred x = x - 1", () => {
       const nsucc: Binding = ["nsucc", lam("x", add(_var("x"), int(1)))];
 
       const env: Env = Map();
       const result = inferExpr(env, nsucc[1]);
 
-      expect(print(result)).toEqual("(Int -> Int)");
+      expect(print(result)).toEqual("Int -> Int");
     });
   });
 
@@ -179,14 +181,154 @@ describe("inferExpr", () => {
       const env: Env = Map();
       const result = inferExpr(env, fib[1]);
 
-      expect(print(result)).toEqual("(Int -> Int)");
+      expect(print(result)).toEqual("Int -> Int");
     });
 
-    test.todo("let const = (x) => (y) => x");
-    test.todo("let compose = (f) => (g) => (x) => f(g(x))");
-    test.todo("let twice = (f) => (x) => f(f(x))");
-    test.todo("let on = ...");
-    test.todo("let ap = ...");
+    test("let const = (x) => (y) => x", () => {
+      let env: Env = Map();
+      const result = inferExpr(env, _const[1]);
+
+      expect(print(result)).toEqual("forall a, b => a -> b -> a");
+    });
+
+    test("issue #82", () => {
+      // let y = \y -> (let f = \x -> if x then True else False in const (f y) y);
+      const y: Binding = [
+        "y",
+        lam(
+          "y",
+          _let(
+            "f",
+            lam("x", _if(_var("x"), bool(true), bool(false))),
+            app(app(_var("const"), app(_var("f"), _var("y"))), _var("y"))
+          )
+        ),
+      ];
+      // let id x = x;
+      const id: Binding = ["id", lam("x", _var("x"))];
+      // let foo x = let y = id x in y + 1;
+      const foo: Binding = [
+        "foo",
+        lam("x", _let("y", app(_var("id"), _var("x")), add(_var("y"), int(1)))),
+      ];
+
+      let env: Env = Map();
+      env = env.set(_const[0], inferExpr(env, _const[1]));
+      env = env.set(y[0], inferExpr(env, y[1]));
+      env = env.set(id[0], inferExpr(env, id[1]));
+      env = env.set(foo[0], inferExpr(env, foo[1]));
+
+      const fooType = env.get("foo");
+      if (!fooType) {
+        throw new Error("foo is undefined");
+      }
+
+      expect(print(fooType)).toEqual("Int -> Int");
+
+      const yType = env.get("y");
+      if (!yType) {
+        throw new Error("y is undefined");
+      }
+
+      expect(print(yType)).toEqual("Bool -> Bool");
+    });
+
+    test("let compose = (f) => (g) => (x) => g(f(x))", () => {
+      // compose f g x == g (f x)
+      const compose: Binding = [
+        "compose",
+        lam("f", lam("g", lam("x", app(_var("g"), app(_var("f"), _var("x")))))),
+      ];
+
+      let env: Env = Map();
+      const result = inferExpr(env, compose[1]);
+
+      expect(print(result)).toEqual(
+        "forall a, b, c => (a -> b) -> (b -> c) -> a -> c"
+      );
+    });
+
+    test("let on g f = \\x y -> g (f x) (f y)", () => {
+      const on: Binding = [
+        "on",
+        lam(
+          "g",
+          lam(
+            "f",
+            lam(
+              "x",
+              lam(
+                "y",
+                app(
+                  app(_var("g"), app(_var("f"), _var("x"))),
+                  app(_var("f"), _var("y"))
+                )
+              )
+            )
+          )
+        ),
+      ];
+
+      let env: Env = Map();
+      const result = inferExpr(env, on[1]);
+
+      expect(print(result)).toEqual(
+        // g: a -> a -> b
+        // f: c -> a
+        "forall a, b, c => (a -> a -> b) -> (c -> a) -> c -> c -> b"
+      );
+    });
+
+    test("let ap f x = f (f x);", () => {
+      const ap: Binding = [
+        "ap",
+        lam("f", lam("x", app(_var("f"), app(_var("f"), _var("x")))))
+      ];
+
+      let env: Env = Map();
+      const result = inferExpr(env, ap[1]);
+
+      expect(print(result)).toEqual("forall a => (a -> a) -> a -> a");
+    });
+
+    test("until", () => {
+      const until: Binding = [
+        "until",
+        // let rec until p f x =
+        fix(
+          lam(
+            "until",
+            lam(
+              "p",
+              lam(
+                "f",
+                lam(
+                  "x",
+                  _if(
+                    //   if (p x)
+                    app(_var("p"), _var("x")),
+                    //   then x
+                    _var("x"),
+                    //   else (until p f (f x));
+                    app(
+                      app(app(_var("until"), _var("p")), _var("f")),
+                      app(_var("f"), _var("x"))
+                    )
+                  )
+                )
+              )
+            )
+          )
+        ),
+      ];
+
+      let env: Env = Map();
+      const result = inferExpr(env, until[1]);
+
+      expect(print(result)).toEqual(
+        "forall a => (a -> Bool) -> (a -> a) -> a -> a"
+      );
+    });
   });
 
   describe("Let Polymorphism", () => {
@@ -214,7 +356,7 @@ describe("inferExpr", () => {
       const env: Env = Map();
       const result = inferExpr(env, self[1]);
 
-      expect(print(result)).toEqual("forall a => (a -> a)");
+      expect(print(result)).toEqual("forall a => a -> a");
     });
 
     test("let innerlet = (x) => (let y = (z) => z in y)", () => {
@@ -227,11 +369,55 @@ describe("inferExpr", () => {
       const result = inferExpr(env, innerlet[1]);
 
       // the 'x' param is ignored
-      expect(print(result)).toEqual("forall a, b => (a -> (b -> b))");
+      expect(print(result)).toEqual("forall a, b => a -> b -> b");
     });
 
     // The expression tree for `let rec` appears to be the same as that
     // for `let`.
     test.todo("let innerletrec = (x) => (let rec y = (z) => z in y)");
+
+    test("let f = let add = a b -> a + b in add;", () => {
+      const f: Binding = [
+        "f",
+        _let("add", lam("a", lam("b", add(_var("a"), _var("b")))), _var("add")),
+      ];
+
+      const env: Env = Map();
+      const result = inferExpr(env, f[1]);
+
+      expect(print(result)).toEqual("Int -> Int -> Int");
+    });
+  });
+
+  describe("errors", () => {
+    test("UnboundVariable", () => {
+      const unbound: Binding = ["unbound", app(_var("foo"), _var("x"))];
+
+      const env: Env = Map();
+
+      expect(() =>
+        inferExpr(env, unbound[1])
+      ).toThrowErrorMatchingInlineSnapshot(`"foo is unbound"`);
+    });
+
+    test("UnificationFail", () => {
+      const fail: Binding = ["fail", lam("foo", add(bool(true), bool(false)))];
+
+      const env: Env = Map();
+
+      expect(() => inferExpr(env, fail[1])).toThrowErrorMatchingInlineSnapshot(
+        `"Couldn't unify Bool with Int"`
+      );
+    });
+
+    test("InfiniteType", () => {
+      const omega: Binding = ["omega", lam("x", app(_var("x"), _var("x")))];
+
+      const env: Env = Map();
+
+      expect(() => inferExpr(env, omega[1])).toThrowErrorMatchingInlineSnapshot(
+        `"b appears in b -> c"`
+      );
+    });
   });
 });

--- a/write-you-a-haskell/src/__tests__/infer.test.ts
+++ b/write-you-a-haskell/src/__tests__/infer.test.ts
@@ -1,168 +1,187 @@
 import { Map } from "immutable";
 
-import { constraintsExpr, inferExpr } from "../infer";
+import { inferExpr } from "../infer";
 import { Expr } from "../syntax";
 import { Env, print } from "../type";
 
 type Binding = [string, Expr];
 
-const I: Binding = [
-  "I",
-  {
-    tag: "Lam",
-    arg: "x",
-    body: { tag: "Var", name: "x" },
-  },
-];
+const app = (fn: Expr, arg: Expr): Expr => ({ tag: "App", fn, arg });
+const _if = (cond: Expr, th: Expr, el: Expr): Expr => ({
+  tag: "If",
+  cond,
+  th,
+  el,
+});
+const fix = (expr: Expr): Expr => ({ tag: "Fix", expr });
+const lam = (arg: string, body: Expr): Expr => ({ tag: "Lam", arg, body });
+const _let = (name: string, value: Expr, body: Expr): Expr => ({
+  tag: "Let",
+  name,
+  value,
+  body,
+});
+const _var = (name: string): Expr => ({ tag: "Var", name });
 
-const K: Binding = [
-  "K",
-  {
-    tag: "Lam",
-    arg: "x",
-    body: {
-      tag: "Lam",
-      arg: "y",
-      body: { tag: "Var", name: "x" },
-    },
-  },
-];
+const int = (value: number): Expr => ({
+  tag: "Lit",
+  value: { tag: "LInt", value },
+});
+const bool = (value: boolean): Expr => ({
+  tag: "Lit",
+  value: { tag: "LBool", value },
+});
 
+const add = (left: Expr, right: Expr): Expr => ({
+  tag: "Op",
+  op: "Add",
+  left,
+  right,
+});
+const sub = (left: Expr, right: Expr): Expr => ({
+  tag: "Op",
+  op: "Sub",
+  left,
+  right,
+});
+const mul = (left: Expr, right: Expr): Expr => ({
+  tag: "Op",
+  op: "Mul",
+  left,
+  right,
+});
+const eql = (left: Expr, right: Expr): Expr => ({
+  tag: "Op",
+  op: "Eql",
+  left,
+  right,
+});
+
+const I: Binding = ["I", lam("x", _var("x"))];
+const K: Binding = ["K", lam("x", lam("y", _var("x")))];
 // let S = (f) => (g) => (x) => f(x)(g(x))
 const S: Binding = [
   "S",
-  {
-    tag: "Lam",
-    arg: "f",
-    body: {
-      tag: "Lam",
-      arg: "g",
-      body: {
-        tag: "Lam",
-        arg: "x",
-        body: {
-          tag: "App",
-          fn: {
-            tag: "App",
-            fn: { tag: "Var", name: "f" },
-            arg: { tag: "Var", name: "x" },
-          },
-          arg: {
-            tag: "App",
-            fn: { tag: "Var", name: "g" },
-            arg: { tag: "Var", name: "x" },
-          },
-        },
-      },
-    },
-  },
+  lam(
+    "f",
+    lam(
+      "g",
+      lam("x", app(app(_var("f"), _var("x")), app(_var("g"), _var("x"))))
+    )
+  ),
 ];
 
 describe("inferExpr", () => {
   describe("SKI cominbators", () => {
-
     test("let I x = x", () => {
       const env: Env = Map();
       const result = inferExpr(env, I[1]);
-  
+
       expect(print(result)).toEqual("forall a => (a -> a)");
     });
-  
+
     test("let K x y = x", () => {
       const env: Env = Map();
       const result = inferExpr(env, K[1]);
-  
+
       expect(print(result)).toEqual("forall a, b => (a -> (b -> a))");
     });
-  
+
     test("let S f g x = f x (g x)", () => {
       const env: Env = Map();
       const result = inferExpr(env, S[1]);
-  
+
       expect(print(result)).toEqual(
         "forall a, b, c => ((a -> (b -> c)) -> ((a -> b) -> (a -> c)))"
       );
     });
-  
+
     test("SKK", () => {
-      const S: Binding = [
-        "S",
-        {
-          tag: "Lam",
-          arg: "f",
-          body: {
-            tag: "Lam",
-            arg: "g",
-            body: {
-              tag: "Lam",
-              arg: "x",
-              body: {
-                tag: "App",
-                fn: {
-                  tag: "App",
-                  fn: { tag: "Var", name: "f" },
-                  arg: { tag: "Var", name: "x" },
-                },
-                arg: {
-                  tag: "App",
-                  fn: { tag: "Var", name: "g" },
-                  arg: { tag: "Var", name: "x" },
-                },
-              },
-            },
-          },
-        },
-      ];
-  
-      const skk: Binding = [
-        "skk",
-        {
-          tag: "App",
-          fn: {
-            tag: "App",
-            fn: { tag: "Var", name: "S" },
-            arg: { tag: "Var", name: "K" },
-          },
-          arg: { tag: "Var", name: "K" },
-        },
-      ];
-  
+      const skk: Binding = ["skk", app(app(_var("S"), _var("K")), _var("K"))];
+
       let env: Env = Map();
       env = env.set(S[0], inferExpr(env, S[1]));
       env = env.set(K[0], inferExpr(env, K[1]));
       env = env.set(skk[0], inferExpr(env, skk[1]));
-  
+
       const result = env.get("skk");
       if (!result) {
         throw new Error("skk is undefined");
       }
-  
+
       expect(print(result)).toEqual("forall a => (a -> a)");
     });
-  
+
     test("Mu f = f (fix f)", () => {
-      const K: Binding = [
-        "Mu",
-        {
-          tag: "Lam",
-          arg: "f",
-          body: {
-            tag: "App",
-            fn: { tag: "Var", name: "f" },
-            arg: { tag: "Fix", expr: { tag: "Var", name: "f" } },
-          },
-        },
-      ];
-  
+      const Mu: Binding = ["Mu", lam("f", app(_var("f"), fix(_var("f"))))];
+
       const env: Env = Map();
-      const result = inferExpr(env, K[1]);
-  
+      const result = inferExpr(env, Mu[1]);
+
       expect(print(result)).toEqual("forall a => ((a -> a) -> a)");
     });
   });
 
+  describe("Integer arithmetic", () => {
+    describe("let nsucc x = x + 1", () => {
+      const nsucc: Binding = ["nsucc", lam("x", add(_var("x"), int(1)))];
+
+      const env: Env = Map();
+      const result = inferExpr(env, nsucc[1]);
+
+      expect(print(result)).toEqual("(Int -> Int)");
+    });
+
+    describe("let npred x = x - 1", () => {
+      const nsucc: Binding = ["nsucc", lam("x", add(_var("x"), int(1)))];
+
+      const env: Env = Map();
+      const result = inferExpr(env, nsucc[1]);
+
+      expect(print(result)).toEqual("(Int -> Int)");
+    });
+  });
+
   describe("Functions", () => {
-    test.todo("let rec fib = (n) => ...");
+    test("let rec fib = (n) => ...", () => {
+      // letrecdecl takes
+      // `let rec fib = (n) => ...`
+      // and converts it to
+      // `let fib = fix((fib) => (n) => ...)`
+      const fib: Binding = [
+        "fib",
+        fix(
+          lam(
+            "fib",
+            lam(
+              "n",
+              _if(
+                eql(_var("n"), int(0)),
+                // then
+                int(0),
+                // else
+                _if(
+                  eql(_var("n"), int(1)),
+                  // then
+                  int(1),
+                  // else
+                  add(
+                    app(_var("fib"), sub(_var("n"), int(1))),
+                    app(_var("fib"), sub(_var("n"), int(2)))
+                  )
+                )
+              )
+            )
+          )
+        ),
+      ];
+
+      const env: Env = Map();
+      const result = inferExpr(env, fib[1]);
+
+      expect(print(result)).toEqual("(Int -> Int)");
+    });
+
     test.todo("let const = (x) => (y) => x");
     test.todo("let compose = (f) => (g) => (x) => f(g(x))");
     test.todo("let twice = (f) => (x) => f(f(x))");
@@ -172,49 +191,24 @@ describe("inferExpr", () => {
 
   describe("Let Polymorphism", () => {
     test("let poly = I (I I) (I 3);", () => {
-      const poly: Binding = [
-        "poly",
-        {
-          tag: "App",
-          fn: {
-            tag: "App",
-            fn: I[1],
-            arg: I[1],
-          },
-          arg: {
-            tag: "App",
-            fn: I[1],
-            arg: {
-              tag: "Lit",
-              value: {
-                tag: "LInt",
-                value: 3,
-              }
-            }
-          }
-        }
-      ];
+      const poly: Binding = ["poly", app(app(I[1], I[1]), app(I[1], int(3)))];
 
       let env: Env = Map();
       env = env.set(I[0], inferExpr(env, I[1]));
       env = env.set(poly[0], inferExpr(env, poly[1]));
-  
+
       const result = env.get("poly");
       if (!result) {
         throw new Error("poly is undefined");
       }
-  
+
       expect(print(result)).toEqual("Int");
     });
 
     test("let self = ((x) => x)((x) => x)", () => {
       const self: Binding = [
         "self",
-        {
-          tag: "App",
-          fn: {tag: "Lam", arg: "x", body: {tag: "Var", name: "x"}},
-          arg: {tag: "Lam", arg: "x", body: {tag: "Var", name: "x"}},
-        },
+        app(lam("x", _var("x")), lam("x", _var("x"))),
       ];
 
       const env: Env = Map();
@@ -226,20 +220,7 @@ describe("inferExpr", () => {
     test("let innerlet = (x) => (let y = (z) => z in y)", () => {
       const innerlet: Binding = [
         "innerlet",
-        {
-          tag: "Lam",
-          arg: "x",
-          body: {
-            tag: "Let",
-            name: "y",
-            value: {
-              tag: "Lam",
-              arg: "z",
-              body: {tag: "Var", name: "z"},
-            },
-            body: {tag: "Var", name: "y"},
-          }
-        }
+        lam("x", _let("y", lam("z", _var("z")), _var("y"))),
       ];
 
       const env: Env = Map();
@@ -250,7 +231,7 @@ describe("inferExpr", () => {
     });
 
     // The expression tree for `let rec` appears to be the same as that
-    // for `let`.  
+    // for `let`.
     test.todo("let innerletrec = (x) => (let rec y = (z) => z in y)");
-  });  
+  });
 });

--- a/write-you-a-haskell/src/errors.ts
+++ b/write-you-a-haskell/src/errors.ts
@@ -1,0 +1,42 @@
+import { print, TVar, Type, Constraint } from "./type";
+
+export class UnificationFail extends Error {
+  constructor(a: Type, b: Type) {
+    const message = `Couldn't unify ${print(a)} with ${print(b)}`;
+    super(message);
+    this.name = "UnificationFail";
+  }
+}
+
+export class InfiniteType extends Error {
+  constructor(a: TVar, b: Type) {
+    const message = `${print(a)} appears in ${print(b)}`;
+    super(message);
+    this.name = "InfiniteType";
+  }
+}
+
+export class UnboundVariable extends Error {
+  constructor(name: string) {
+    const message = `${name} is unbound`;
+    super(message);
+    this.name = "UnboundVariable";
+  }
+}
+
+export class Ambiguous extends Error {
+  constructor(constraints: Constraint[]) {
+    const message = constraints
+      .map(([a, b]) => `${print(a)} = ${print(b)}`)
+      .join(", ");
+    super(message);
+    this.name = "Ambiguous";
+  }
+}
+
+export class UnificationMismatch extends Error {
+  constructor(as: Type[], bs: Type[]) {
+    super("UnificationMismatch");
+    this.name = "UnificationMismatch";
+  }
+}

--- a/write-you-a-haskell/src/infer.ts
+++ b/write-you-a-haskell/src/infer.ts
@@ -1,0 +1,456 @@
+import { Map, Set } from "immutable";
+
+import {
+  InfiniteType,
+  UnboundVariable,
+  UnificationFail,
+  UnificationMismatch,
+} from "./errors";
+import {
+  Type,
+  TVar,
+  Scheme,
+  TArr,
+  TCon,
+  Subst,
+  Env,
+  Constraint,
+  Unifier,
+  equal,
+  tInt,
+  tBool,
+  print,
+} from "./type";
+import { Expr } from "./syntax";
+
+const isTCon = (t: any): t is TCon => t.tag === "TCon";
+const isTVar = (t: any): t is TVar => t.tag === "TVar";
+const isTArr = (t: any): t is TArr => t.tag === "TArr";
+const isScheme = (t: any): t is Scheme => t.tag === "Forall";
+
+function apply(s: Subst, type: Type): Type;
+function apply(s: Subst, scheme: Scheme): Scheme;
+function apply(s: Subst, types: Type[]): Type[];
+function apply(s: Subst, schemes: Scheme[]): Scheme[];
+function apply(s: Subst, constraint: Constraint): Constraint; // special case of Type[]
+function apply(s: Subst, constraint: Constraint[]): Constraint[]; // this should just work
+function apply(s: Subst, env: Env): Env;
+function apply(s: Subst, a: any): any {
+  // instance Substitutable Type
+  if (isTCon(a)) {
+    return a;
+  }
+  if (isTVar(a)) {
+    return s.get(a.name) || a;
+  }
+  if (isTArr(a)) {
+    return {
+      tag: "TArr",
+      arg: apply(s, a.arg),
+      ret: apply(s, a.ret),
+    };
+  }
+
+  // instance Substitutable Scheme
+  if (isScheme(a)) {
+    return {
+      tag: "Forall",
+      qualifiers: a.qualifiers,
+      type: apply(
+        // remove all TVars from the Substitution mapping that appear in the scheme as
+        // qualifiers.
+        // TODO: should this be using reduceRight to match Infer.hs' use of foldr?
+        a.qualifiers.reduce((accum, val) => accum.delete(val.name), s),
+        a.type
+      ),
+    };
+  }
+
+  // instance Substitutable Constraint
+  // instance Substitutable a => Substitutable [a]
+  if (Array.isArray(a)) {
+    return a.map((t) => apply(s, t));
+  }
+
+  // instance Substitutable Env
+  if (Map.isMap(a)) {
+    return (a as Env).map((sc) => apply(s, sc));
+  }
+
+  throw new Error(`apply doesn't handle ${a}`);
+}
+
+function ftv(type: Type): Set<TVar>;
+function ftv(scheme: Scheme): Set<TVar>;
+function ftv(types: Type[]): Set<TVar>;
+function ftv(schemes: Scheme[]): Set<TVar>;
+function ftv(constraint: Constraint): Set<TVar>; // special case of Type[]
+function ftv(env: Env): Set<TVar>;
+function ftv(a: any): any {
+  // instance Substitutable Type
+  if (isTCon(a)) {
+    return Set(); // Set.empty
+  }
+  if (isTVar(a)) {
+    return Set([a]); // Set.singleton a
+  }
+  if (isTArr(a)) {
+    return Set.union([ftv(a.arg), ftv(a.ret)]); // ftv t1 `Set.union` ftv t2
+  }
+
+  // instance Substitutable Scheme
+  if (isScheme(a)) {
+    return ftv(a.type).subtract(a.qualifiers);
+  }
+
+  // instance Substitutable Constraint
+  // instance Substitutable a => Substitutable [a]
+  if (Array.isArray(a)) {
+    return Set.union(a.map(ftv));
+  }
+
+  // instance Substitutable Env
+  if (Map.isMap(a)) {
+    const env = a as Env;
+    return Set.union(env.valueSeq().map(ftv));
+  }
+
+  throw new Error(`ftv doesn't handle ${a}`);
+}
+
+type State = {
+  count: number;
+};
+
+type Context = {
+  env: Env;
+  state: State;
+};
+
+const emptyEnv: Env = Map();
+
+export const inferExpr = (env: Env, expr: Expr): Scheme => {
+  const initCtx: Context = {
+    env: env,
+    state: {count: 0},
+  };
+  const [ty, cs] = infer(expr, initCtx);
+  const subs = runSolve(cs);
+  return closeOver(apply(subs, ty));
+}
+
+//  Return the internal constraints used in solving for the type of an expression
+export const constraintsExpr = (
+  env: Env,
+  expr: Expr,
+): [Constraint[], Subst, Type, Scheme] => {
+  const initCtx: Context = {
+    env: env,
+    state: {count: 0},
+  };
+  const [ty, cs] = infer(expr, initCtx);
+  const subst = runSolve(cs);
+  const sc = closeOver(apply(subst, ty));
+  return [cs, subst, ty, sc];
+};
+
+// Canonicalize and return the polymorphic toplevel type
+const closeOver = (t: Type): Scheme => {
+  return normalize(generalize(emptyEnv, t));
+};
+
+const generalize = (env: Env, t: Type): Scheme => {
+  return {
+    tag: "Forall",
+    qualifiers: ftv(t).subtract(ftv(env)).toArray(),
+    type: t,
+  };
+};
+
+const lookup = (a: TVar, entries: [TVar, TVar][]): TVar | null => {
+  for (const [k, v] of entries) {
+    // TODO: replace with IDs and generate names when printin
+    if (a.name === k.name) {
+      return v;
+    }
+  }
+  return null;
+}
+
+function fst<A, B>(tuple: [A, B]): A {
+  return tuple[0];
+}
+function snd<A, B>(tuple: [A, B]): B {
+  return tuple[1];
+}
+
+// remove duplicates from the array
+function nub(array: TVar[]): TVar[] {
+  const names: string[] = []
+  return array.filter(tv => {
+    if (!names.includes(tv.name)) {
+      names.push(tv.name);
+      return true;
+    }
+    return false;
+  });
+}
+
+// Renames type variables so that they start with 'a' and there are no gaps
+const normalize = (sc: Scheme): Scheme => {
+  // Returns the names of the free variables in a type
+  const fv = (type: Type): TVar[] => {
+    switch (type.tag) {
+      case "TVar": return [type];
+      // TODO: extend to handle n-ary lambdas
+      case "TArr": return [...fv(type.arg), ...fv(type.ret)];
+      case "TCon": return [];
+    }
+  }
+
+  const body = sc.type;
+  const ord = zip(
+    nub(fv(body)),
+    letters.map(name => ({tag:"TVar", name} as TVar)),
+  );
+
+  const normType = (type: Type): Type => {
+    switch (type.tag) {
+      case "TArr": {
+        // TODO: extend to handle n-ary lambdas
+        const {arg, ret} = type;
+        return {tag: "TArr", arg: normType(arg), ret: normType(ret)};
+      }
+      case "TCon": return type;
+      case "TVar": {
+        const replacement = lookup(type, ord);
+        if (replacement) {
+          return replacement;
+        } else {
+          throw new Error("type variable not in signature")
+        }
+      }
+    }
+  }
+
+  return {
+    tag: "Forall",
+    qualifiers: ord.map(snd),
+    type: normType(body),
+  }
+};
+
+// // Extend type environment
+// // From the usage in Infer.hs, it looks like this executes some code using the
+// // new Context, in particular we run infer with a new Context object
+// const inEnv = (x: string, sc: Scheme, ctx: Context): [Type, Constraint[]] => {
+//   // let scope e = (remove e x) `extend` (x, sc)
+//   // local scope m
+//   // TODO: how do we make this change to env local?
+//   // TODO: it looks like `x` gets remove from the current (local?) environment
+//   ctx.env = ctx.env.set(x, sc);
+// };
+
+// Lookup type in the environment
+const lookupEnv = (name: string, ctx: Context): Type => {
+  const value = ctx.env.get(name);
+  if (!value) {
+    throw new UnboundVariable(name);
+  }
+  return instantiate(value, ctx);
+};
+
+function zip<A, B>(as: readonly A[], bs: readonly B[]): [A, B][] {
+  const length = Math.min(as.length, bs.length);
+  const result: [A, B][] = [];
+  for (let i = 0; i < length; i++) {
+    result.push([as[i], bs[i]]);
+  }
+  return result;
+}
+
+const letters = [
+  "a",
+  "b",
+  "c",
+  "d",
+  "e",
+  "f",
+  "g",
+  "h",
+  "i",
+  "j",
+  "k",
+  "l",
+  "m",
+  "n",
+  "o",
+  "p",
+  "q",
+  "r",
+  "s",
+  "t",
+  "u",
+  "v",
+  "w",
+  "x",
+  "y",
+  "z",
+];
+
+// TODO: use IDs for TVar's and defer naming until print time
+const fresh = (ctx: Context): Type => {
+  ctx.state.count++;
+  return {
+    tag: "TVar",
+    name: letters[ctx.state.count],
+  };
+};
+
+const instantiate = (sc: Scheme, ctx: Context): Type => {
+  const freshQualifiers = sc.qualifiers.map(() => fresh(ctx));
+  const subs = Map(zip(sc.qualifiers.map(qual => qual.name), freshQualifiers));
+  return apply(subs, sc.type);
+};
+
+const infer = (expr: Expr, ctx: Context): [Type, Constraint[]] => {
+  switch (expr.tag) {
+    case "Lit": {
+      const lit = expr.value;
+      switch (lit.tag) {
+        case "LInt":
+          return [tInt, []];
+        case "LBool":
+          return [tBool, []];
+      }
+    }
+
+    case "Var": {
+      const t = lookupEnv(expr.name, ctx);
+      return [t, []];
+    }
+
+    case "Lam": {
+      const { arg, body } = expr;
+      const tv = fresh(ctx);
+      const sc: Scheme = { tag: "Forall", qualifiers: [], type: tv };
+      // What happens with ctx.count?  Is there overlap between variable
+      // names in different contexts?
+      // TODO: just use unique IDs for type vars
+      const newCtx = { ...ctx, env: ctx.env.set(arg, sc) }; // inEnv (x, Forall [] tv)
+      // newCtx introduces a new scope
+      const [t, c] = infer(body, newCtx);
+      return [{ tag: "TArr", arg: tv, ret: t }, c];
+    }
+
+    case "App": {
+      const { fn, arg } = expr; // TODO: expand to handle multiple args
+      const [t_fn, c_fn] = infer(fn, ctx);
+      const [t_arg, c_arg] = infer(arg, ctx);
+      const tv = fresh(ctx);
+      return [
+        tv,
+        [
+          ...c_fn,
+          ...c_arg,
+          // This is almost the reverse of what we return from the "Lam" case
+          [t_fn, { tag: "TArr", arg: t_arg, ret: tv }],
+        ],
+      ];
+    }
+
+    case "Let": {
+      const { name, value, body } = expr;
+      const { env } = ctx;
+      const [t1, c1] = infer(value, ctx);
+      const subs = runSolve(c1);
+      const sc = generalize(apply(subs, env), apply(subs, t1));
+      // (t2, c2) <- inEnv (x, sc) $ local (apply sub) (infer e2)
+      const newCtx = { ...ctx, env: ctx.env.set(name, sc) };
+      const [in_t2, in_c2] = infer(body, newCtx);
+      const [out_t2, out_c2] = [apply(subs, in_t2), apply(subs, in_c2)];
+      // return (t2, c1 ++ c2)
+      return [out_t2, [...c1, ...out_c2]];
+    }
+
+    case "Fix": {
+      const { expr: e } = expr;
+      let [t1, c1] = infer(e, ctx);
+      const tv = fresh(ctx);
+      return [tv, [...c1, [{ tag: "TArr", arg: tv, ret: tv }, t1]]];
+    }
+
+    case "Op":
+      throw new Error("TODO: handle Op");
+
+    case "If":
+      throw new Error("TODO: handle If");
+  }
+};
+
+//
+// Constraint Solver
+//
+
+const emptySubst: Subst = Map();
+
+const runSolve = (cs: Constraint[]): Subst => {
+  return solver([emptySubst, cs]);
+};
+
+const unifyMany = (ts1: Type[], ts2: Type[]): Subst => {
+  if (ts1.length !== ts2.length) {
+    throw new UnificationMismatch(ts1, ts2);
+  }
+  if (ts1.length === 0 && ts2.length === 0) {
+    return emptySubst;
+  }
+  const [t1, ...rest1] = ts1;
+  const [t2, ...rest2] = ts2;
+  const su1 = unifies(t1, t2);
+  const su2 = unifyMany(apply(su1, rest1), apply(su1, rest2));
+  return composeSubs(su2, su1);
+};
+
+const unifies = (t1: Type, t2: Type): Subst => {
+  if (equal(t1, t2)) {
+    return emptySubst;
+  } else if (isTVar(t1)) {
+    return bind(t1, t2);
+  } else if (isTVar(t2)) {
+    return bind(t2, t1);
+  } else if (isTArr(t1) && isTArr(t2)) {
+    return unifyMany([t1.arg, t1.ret], [t2.arg, t2.ret]);
+  } else {
+    throw new UnificationFail(t1, t2);
+  }
+};
+
+const composeSubs = (s1: Subst, s2: Subst): Subst => {
+  return s2.map(t => apply(s1, t)).merge(s1);
+}
+
+// Unification solver
+const solver = (u: Unifier): Subst => {
+  const [su, cs] = u;
+  if (cs.length === 0) {
+    return su;
+  }
+  const [[t1, t2], ...cs0] = cs;
+  const su1 = unifies(t1, t2);
+  return solver([composeSubs(su1, su), apply(su1, cs0)]);
+};
+
+const bind = (tv: TVar, t: Type): Subst => {
+  if (t.tag === "TVar" && t.name === tv.name) {
+    return emptySubst;
+  } else if (occursCheck(tv, t)) {
+    throw new InfiniteType(tv, t);
+  } else {
+    return Map([[tv.name, t]]);
+  }
+};
+
+const occursCheck = (tv: TVar, t: Type): boolean => {
+  return ftv(t).includes(tv);
+};

--- a/write-you-a-haskell/src/syntax.ts
+++ b/write-you-a-haskell/src/syntax.ts
@@ -1,0 +1,19 @@
+export type Expr =
+  | { tag: "Var"; name: string }
+  | { tag: "App"; fn: Expr; arg: Expr } // TODO: make this n-ary
+  | { tag: "Lam"; arg: string; body: Expr }
+  | { tag: "Let"; name: string; value: Expr; body: Expr }
+  | { tag: "Lit"; value: Lit }
+  | { tag: "If"; cond: Expr; then: Expr; else: Expr }
+  | { tag: "Fix"; expr: Expr }
+  | { tag: "Op"; op: Binop; left: Expr; right: Expr };
+
+export type Lit =
+  | { tag: "LInt"; value: number }
+  | { tag: "LBool"; value: boolean };
+
+export type Binop = "Add" | "Sub" | "Mul" | "Eql";
+
+export type Program = { tag: "Program"; decls: Decl[]; expr: Expr };
+
+export type Decl = [string, Expr];

--- a/write-you-a-haskell/src/syntax.ts
+++ b/write-you-a-haskell/src/syntax.ts
@@ -4,7 +4,7 @@ export type Expr =
   | { tag: "Lam"; arg: string; body: Expr }
   | { tag: "Let"; name: string; value: Expr; body: Expr }
   | { tag: "Lit"; value: Lit }
-  | { tag: "If"; cond: Expr; then: Expr; else: Expr }
+  | { tag: "If"; cond: Expr; th: Expr; el: Expr }
   | { tag: "Fix"; expr: Expr }
   | { tag: "Op"; op: Binop; left: Expr; right: Expr };
 

--- a/write-you-a-haskell/src/type.ts
+++ b/write-you-a-haskell/src/type.ts
@@ -2,12 +2,13 @@ import { Map } from "immutable";
 
 // TODO: update types to use id's
 export type TVar = { tag: "TVar"; name: string };
+// TODO: update type constructors to have type params so that we can 
+// support Array<T>, Promise<T>, etc. in the future.
 export type TCon = { tag: "TCon"; name: string };
-// TArr === TApp
 // TODO: upgrade arg: Type to args: Type[]
-export type TArr = { tag: "TArr"; arg: Type; ret: Type };
+export type TApp = { tag: "TApp"; arg: Type; ret: Type };
 
-export type Type = TVar | TCon | TArr;
+export type Type = TVar | TCon | TApp;
 
 export type Scheme = { tag: "Forall"; qualifiers: TVar[]; type: Type };
 
@@ -22,8 +23,12 @@ export function print(t: Type | Scheme): string {
     case "TCon": {
       return t.name;
     }
-    case "TArr": {
-      return `(${print(t.arg)} -> ${print(t.ret)})`;
+    case "TApp": {
+      if (t.arg.tag === "TApp") {
+        return `(${print(t.arg)}) -> ${print(t.ret)}`;
+      } else {
+        return `${print(t.arg)} -> ${print(t.ret)}`;
+      }
     }
     case "Forall": {
       return t.qualifiers.length > 0
@@ -39,7 +44,7 @@ export function equal(a: Type | Scheme, b: Type | Scheme): boolean {
   } else if (a.tag === "TCon" && b.tag === "TCon") {
     // TODO: add support for type params to TCon
     return a.name === b.name; 
-  } else if (a.tag === "TArr" && b.tag === "TArr") {
+  } else if (a.tag === "TApp" && b.tag === "TApp") {
     // TODO: add supprt for n-ary application
     return equal(a.arg, b.arg) && equal(a.ret, b.ret);
   } else if (a.tag === "Forall" && b.tag === "Forall") {

--- a/write-you-a-haskell/src/type.ts
+++ b/write-you-a-haskell/src/type.ts
@@ -1,0 +1,58 @@
+import { Map } from "immutable";
+
+// TODO: update types to use id's
+export type TVar = { tag: "TVar"; name: string };
+export type TCon = { tag: "TCon"; name: string };
+// TArr === TApp
+// TODO: upgrade arg: Type to args: Type[]
+export type TArr = { tag: "TArr"; arg: Type; ret: Type };
+
+export type Type = TVar | TCon | TArr;
+
+export type Scheme = { tag: "Forall"; qualifiers: TVar[]; type: Type };
+
+export const tInt: TCon = { tag: "TCon", name: "Int" };
+export const tBool: TCon = { tag: "TCon", name: "Bool" };
+
+export function print(t: Type | Scheme): string {
+  switch (t.tag) {
+    case "TVar": {
+      return t.name;
+    }
+    case "TCon": {
+      return t.name;
+    }
+    case "TArr": {
+      return `(${print(t.arg)} -> ${print(t.ret)})`;
+    }
+    case "Forall": {
+      return t.qualifiers.length > 0
+        ? `forall ${t.qualifiers.map(print).join(", ")} => ${print(t.type)}`
+        : print(t.type);
+    }
+  }
+}
+
+export function equal(a: Type | Scheme, b: Type | Scheme): boolean {
+  if (a.tag === "TVar" && b.tag === "TVar") {
+    return a.name === b.name; // TODO: use IDs
+  } else if (a.tag === "TCon" && b.tag === "TCon") {
+    // TODO: add support for type params to TCon
+    return a.name === b.name; 
+  } else if (a.tag === "TArr" && b.tag === "TArr") {
+    // TODO: add supprt for n-ary application
+    return equal(a.arg, b.arg) && equal(a.ret, b.ret);
+  } else if (a.tag === "Forall" && b.tag === "Forall") {
+    throw new Error("TODO: implement equal for Schemes");
+  }
+  return false;
+}
+
+// Env is a map of all the current schemes (qualified types) that
+// are in scope.
+export type Env = Map<string, Scheme>;
+
+export type Constraint = [Type, Type];
+export type Unifier = [Subst, Constraint[]];
+
+export type Subst = Map<string, Type>;


### PR DESCRIPTION
The previous hindley-milner implementation that I was using doesn't handle let polymorphism.  This one does.  I'll add support for n-ary lambdas, type widening, etc. in future PRs.