### PR TITLE
[wyah]: add support for partial application

### DIFF
--- a/write-you-a-haskell/src/type.ts
+++ b/write-you-a-haskell/src/type.ts
@@ -7,7 +7,7 @@ export type TVar = { tag: "TVar"; name: string };
 // TODO: update type constructors to have type params so that we can
 // support Array<T>, Promise<T>, etc. in the future.
 export type TCon = { tag: "TCon"; name: string };
-export type TApp = { tag: "TApp"; args: Type[]; ret: Type };
+export type TApp = { tag: "TApp"; args: Type[]; ret: Type, src?: "App" | "Fix" | "Lam" };
 
 export type Type = TVar | TCon | TApp;
 
@@ -16,7 +16,6 @@ export type Scheme = { tag: "Forall"; qualifiers: TVar[]; type: Type };
 export const tInt: TCon = { tag: "TCon", name: "Int" };
 export const tBool: TCon = { tag: "TCon", name: "Bool" };
 
-// TODO: add an option to control output style
 export function print(t: Type | Scheme): string {
   switch (t.tag) {
     case "TVar": {


### PR DESCRIPTION
Partial application must happen from the left to right for now.  In the future we can provide syntax for omitting some args in order to partially apply the rest of the args.

This PR also makes `const` in the tests n-ary instead of curried.
