### PR TITLE
[wyah]: allow type constructors to have params

### DIFF
--- a/write-you-a-haskell/src/__tests__/infer.test.ts
+++ b/write-you-a-haskell/src/__tests__/infer.test.ts
@@ -525,7 +525,7 @@ describe("inferExpr", () => {
       let env: Env = Map();
 
       env = env.set("extract", extractScheme);
-        // x is of type Foo<Int>
+      // x is of type Foo<Int>
       env = env.set("x", {
         tag: "Forall",
         qualifiers: [],
@@ -533,7 +533,7 @@ describe("inferExpr", () => {
           tag: "TCon",
           name: "Foo",
           params: [{ tag: "TCon", name: "Int", params: [] }],
-        }
+        },
       });
 
       const extractedX = app(_var("extract"), [_var("x")]);

--- a/write-you-a-haskell/src/__tests__/infer.test.ts
+++ b/write-you-a-haskell/src/__tests__/infer.test.ts
@@ -2,7 +2,7 @@ import { Map } from "immutable";
 
 import { inferExpr } from "../infer";
 import { Expr } from "../syntax";
-import { Env, print } from "../type";
+import { Env, print, Scheme, Type, TVar } from "../type";
 
 type Binding = [string, Expr];
 
@@ -450,6 +450,63 @@ describe("inferExpr", () => {
       const result = inferExpr(env, add5[1]);
 
       expect(print(result)).toEqual("(Int) => Int");
+    });
+  });
+
+  describe("Type Constructors", () => {
+    test("infer promise type", () => {
+      const aVar: TVar = { tag: "TVar", name: "a" };
+      const promisifyType: Type = {
+        tag: "TApp",
+        args: [aVar],
+        ret: { tag: "TCon", name: "Promise", params: [aVar] },
+      };
+      // <a>(a) => Promise<a>
+      const promisifyScheme: Scheme = {
+        tag: "Forall",
+        qualifiers: [aVar],
+        type: promisifyType,
+      };
+
+      let env: Env = Map();
+
+      env = env.set("promisify", promisifyScheme);
+      const intCall: Binding = ["call", app(_var("promisify"), [int(5)])];
+      const intResult = inferExpr(env, intCall[1]);
+      expect(print(intResult)).toEqual("Promise<Int>");
+
+      const boolCall: Binding = ["call", app(_var("promisify"), [bool(true)])];
+      const boolResult = inferExpr(env, boolCall[1]);
+      expect(print(boolResult)).toEqual("Promise<Bool>");
+    });
+
+    test("extract value from type constructor", () => {
+      const aVar: TVar = { tag: "TVar", name: "a" };
+      // <a>(Foo<a>) => a
+      const extractScheme: Scheme = {
+        tag: "Forall",
+        qualifiers: [aVar],
+        type: {
+          tag: "TApp",
+          args: [{ tag: "TCon", name: "Foo", params: [aVar] }],
+          ret: aVar,
+        },
+      };
+
+      let env: Env = Map();
+
+      env = env.set("extract", extractScheme);
+
+      const addFoos = lam(
+        ["x", "y"],
+        add(
+          app(_var("extract"), [_var("x")]),
+          app(_var("extract"), [_var("y")])
+        )
+      );
+
+      const result = inferExpr(env, addFoos);
+      expect(print(result)).toEqual("(Foo<Int>, Foo<Int>) => Int")
     });
   });
 

--- a/write-you-a-haskell/src/__tests__/infer.test.ts
+++ b/write-you-a-haskell/src/__tests__/infer.test.ts
@@ -506,7 +506,40 @@ describe("inferExpr", () => {
       );
 
       const result = inferExpr(env, addFoos);
-      expect(print(result)).toEqual("(Foo<Int>, Foo<Int>) => Int")
+      expect(print(result)).toEqual("(Foo<Int>, Foo<Int>) => Int");
+    });
+
+    test("extract value from type constructor 2", () => {
+      const aVar: TVar = { tag: "TVar", name: "a" };
+      // <a>(Foo<a>) => a
+      const extractScheme: Scheme = {
+        tag: "Forall",
+        qualifiers: [aVar],
+        type: {
+          tag: "TApp",
+          args: [{ tag: "TCon", name: "Foo", params: [aVar] }],
+          ret: aVar,
+        },
+      };
+
+      let env: Env = Map();
+
+      env = env.set("extract", extractScheme);
+        // x is of type Foo<Int>
+      env = env.set("x", {
+        tag: "Forall",
+        qualifiers: [],
+        type: {
+          tag: "TCon",
+          name: "Foo",
+          params: [{ tag: "TCon", name: "Int", params: [] }],
+        }
+      });
+
+      const extractedX = app(_var("extract"), [_var("x")]);
+
+      const result = inferExpr(env, extractedX);
+      expect(print(result)).toEqual("Int");
     });
   });
 

--- a/write-you-a-haskell/src/infer.ts
+++ b/write-you-a-haskell/src/infer.ts
@@ -410,7 +410,10 @@ const infer = (expr: Expr, ctx: Context): [Type, Constraint[]] => {
       const { expr: e } = expr;
       let [t1, c1] = infer(e, ctx);
       const tv = fresh(ctx);
-      return [tv, [...c1, [{ tag: "TApp", args: [tv], ret: tv, src: "Fix" }, t1]]];
+      return [
+        tv,
+        [...c1, [{ tag: "TApp", args: [tv], ret: tv, src: "Fix" }, t1]],
+      ];
     }
 
     case "Op": {

--- a/write-you-a-haskell/src/infer.ts
+++ b/write-you-a-haskell/src/infer.ts
@@ -45,7 +45,11 @@ function apply(s: Subst, env: Env): Env;
 function apply(s: Subst, a: any): any {
   // instance Substitutable Type
   if (isTCon(a)) {
-    return a;
+    return {
+      tag: "TCon",
+      name: a.name,
+      params: apply(s, a.params),
+    };
   }
   if (isTVar(a)) {
     return s.get(a.name) || a;
@@ -96,7 +100,7 @@ function ftv(env: Env): Set<TVar>;
 function ftv(a: any): any {
   // instance Substitutable Type
   if (isTCon(a)) {
-    return Set(); // Set.empty
+    return Set.union(a.params.map(ftv));
   }
   if (isTVar(a)) {
     return Set([a]); // Set.singleton a
@@ -490,6 +494,9 @@ export const unifies = (t1: Type, t2: Type): Subst => {
     }
 
     return unifyMany([...t1.args, t1.ret], [...t2.args, t2.ret]);
+  } else if (isTCon(t1) && isTCon(t2) && t1.name === t2.name) {
+    // TODO: figure out how to write a test for this
+    return unifyMany(t1.params, t2.params);
   } else {
     throw new UnificationFail(t1, t2);
   }

--- a/write-you-a-haskell/src/infer.ts
+++ b/write-you-a-haskell/src/infer.ts
@@ -495,7 +495,6 @@ export const unifies = (t1: Type, t2: Type): Subst => {
 
     return unifyMany([...t1.args, t1.ret], [...t2.args, t2.ret]);
   } else if (isTCon(t1) && isTCon(t2) && t1.name === t2.name) {
-    // TODO: figure out how to write a test for this
     return unifyMany(t1.params, t2.params);
   } else {
     throw new UnificationFail(t1, t2);

--- a/write-you-a-haskell/src/type.ts
+++ b/write-you-a-haskell/src/type.ts
@@ -7,7 +7,12 @@ export type TVar = { tag: "TVar"; name: string };
 // TODO: update type constructors to have type params so that we can
 // support Array<T>, Promise<T>, etc. in the future.
 export type TCon = { tag: "TCon"; name: string; params: Type[] };
-export type TApp = { tag: "TApp"; args: Type[]; ret: Type, src?: "App" | "Fix" | "Lam" };
+export type TApp = {
+  tag: "TApp";
+  args: Type[];
+  ret: Type;
+  src?: "App" | "Fix" | "Lam";
+};
 
 export type Type = TVar | TCon | TApp;
 
@@ -24,17 +29,17 @@ export function print(t: Type | Scheme): string {
     case "TCon": {
       return t.params.length > 0
         ? `${t.name}<${t.params.map((param) => print(param)).join(", ")}>`
-        : t.name
+        : t.name;
     }
     case "TApp": {
-      return `(${t.args
-        .map((arg) => print(arg))
-        .join(", ")}) => ${print(t.ret)}`;
+      return `(${t.args.map((arg) => print(arg)).join(", ")}) => ${print(
+        t.ret
+      )}`;
     }
     case "Forall": {
       return t.qualifiers.length > 0
         ? `<${t.qualifiers.map((qual) => print(qual)).join(", ")}>${print(
-            t.type,
+            t.type
           )}`
         : print(t.type);
     }
@@ -46,7 +51,11 @@ export function equal(a: Type | Scheme, b: Type | Scheme): boolean {
     return a.name === b.name; // TODO: use IDs
   } else if (a.tag === "TCon" && b.tag === "TCon") {
     // TODO: add support for type params to TCon
-    return a.name === b.name;
+    return (
+      a.name === b.name &&
+      a.params.length === b.params.length &&
+      zip(a.params, b.params).every((pair) => equal(...pair))
+    );
   } else if (a.tag === "TApp" && b.tag === "TApp") {
     return (
       a.args.length === b.args.length &&

--- a/write-you-a-haskell/src/type.ts
+++ b/write-you-a-haskell/src/type.ts
@@ -50,7 +50,6 @@ export function equal(a: Type | Scheme, b: Type | Scheme): boolean {
   if (a.tag === "TVar" && b.tag === "TVar") {
     return a.name === b.name; // TODO: use IDs
   } else if (a.tag === "TCon" && b.tag === "TCon") {
-    // TODO: add support for type params to TCon
     return (
       a.name === b.name &&
       a.params.length === b.params.length &&

--- a/write-you-a-haskell/src/type.ts
+++ b/write-you-a-haskell/src/type.ts
@@ -4,8 +4,6 @@ import { zip } from "./util";
 
 // TODO: update types to use id's
 export type TVar = { tag: "TVar"; name: string };
-// TODO: update type constructors to have type params so that we can
-// support Array<T>, Promise<T>, etc. in the future.
 export type TCon = { tag: "TCon"; name: string; params: Type[] };
 export type TApp = {
   tag: "TApp";

--- a/write-you-a-haskell/src/type.ts
+++ b/write-you-a-haskell/src/type.ts
@@ -6,15 +6,15 @@ import { zip } from "./util";
 export type TVar = { tag: "TVar"; name: string };
 // TODO: update type constructors to have type params so that we can
 // support Array<T>, Promise<T>, etc. in the future.
-export type TCon = { tag: "TCon"; name: string };
+export type TCon = { tag: "TCon"; name: string; params: Type[] };
 export type TApp = { tag: "TApp"; args: Type[]; ret: Type, src?: "App" | "Fix" | "Lam" };
 
 export type Type = TVar | TCon | TApp;
 
 export type Scheme = { tag: "Forall"; qualifiers: TVar[]; type: Type };
 
-export const tInt: TCon = { tag: "TCon", name: "Int" };
-export const tBool: TCon = { tag: "TCon", name: "Bool" };
+export const tInt: TCon = { tag: "TCon", name: "Int", params: [] };
+export const tBool: TCon = { tag: "TCon", name: "Bool", params: [] };
 
 export function print(t: Type | Scheme): string {
   switch (t.tag) {
@@ -22,7 +22,9 @@ export function print(t: Type | Scheme): string {
       return t.name;
     }
     case "TCon": {
-      return t.name;
+      return t.params.length > 0
+        ? `${t.name}<${t.params.map((param) => print(param)).join(", ")}>`
+        : t.name
     }
     case "TApp": {
       return `(${t.args

--- a/write-you-a-haskell/src/type.ts
+++ b/write-you-a-haskell/src/type.ts
@@ -25,9 +25,8 @@ export function print(t: Type | Scheme): string {
       return t.name;
     }
     case "TCon": {
-      return t.params.length > 0
-        ? `${t.name}<${t.params.map((param) => print(param)).join(", ")}>`
-        : t.name;
+      const params = t.params.map((param) => print(param)).join(", ");
+      return t.params.length > 0 ? `${t.name}<${params}>` : t.name;
     }
     case "TApp": {
       return `(${t.args.map((arg) => print(arg)).join(", ")}) => ${print(
@@ -35,11 +34,9 @@ export function print(t: Type | Scheme): string {
       )}`;
     }
     case "Forall": {
-      return t.qualifiers.length > 0
-        ? `<${t.qualifiers.map((qual) => print(qual)).join(", ")}>${print(
-            t.type
-          )}`
-        : print(t.type);
+      const quals = t.qualifiers.map((qual) => print(qual)).join(", ");
+      const type = print(t.type);
+      return t.qualifiers.length > 0 ? `<${quals}>${type}` : type;
     }
   }
 }


### PR DESCRIPTION
The tests show wrapping a type in a `Promise<>` and unwrapping the value from a `Foo<>`.