### PR TITLE
Make most arrays/tuples readonly

### DIFF
--- a/write-you-a-haskell/src/errors.ts
+++ b/write-you-a-haskell/src/errors.ts
@@ -35,7 +35,7 @@ export class Ambiguous extends Error {
 }
 
 export class UnificationMismatch extends Error {
-  constructor(as: Type[], bs: Type[]) {
+  constructor(as: readonly Type[], readonly bs: readonly Type[]) {
     super("UnificationMismatch");
     this.name = "UnificationMismatch";
   }

--- a/write-you-a-haskell/src/infer.ts
+++ b/write-you-a-haskell/src/infer.ts
@@ -24,7 +24,7 @@ import {
 import { Binop, Expr } from "./syntax";
 import { snd, zip } from "./util";
 
-const scheme = (qualifiers: TVar[], type: Type): Scheme => ({
+const scheme = (qualifiers: readonly TVar[], type: Type): Scheme => ({
   tag: "Forall",
   qualifiers,
   type,
@@ -37,10 +37,10 @@ const isScheme = (t: any): t is Scheme => t.tag === "Forall";
 
 function apply(s: Subst, type: Type): Type;
 function apply(s: Subst, scheme: Scheme): Scheme;
-function apply(s: Subst, types: Type[]): Type[];
-function apply(s: Subst, schemes: Scheme[]): Scheme[];
+function apply(s: Subst, types: readonly Type[]): readonly Type[];
+function apply(s: Subst, schemes: readonly Scheme[]): readonly Scheme[];
 function apply(s: Subst, constraint: Constraint): Constraint; // special case of Type[]
-function apply(s: Subst, constraint: Constraint[]): Constraint[]; // this should just work
+function apply(s: Subst, constraint: readonly Constraint[]): readonly Constraint[]; // this should just work
 function apply(s: Subst, env: Env): Env;
 function apply(s: Subst, a: any): any {
   // instance Substitutable Type
@@ -93,8 +93,8 @@ function apply(s: Subst, a: any): any {
 
 function ftv(type: Type): Set<TVar>;
 function ftv(scheme: Scheme): Set<TVar>;
-function ftv(types: Type[]): Set<TVar>;
-function ftv(schemes: Scheme[]): Set<TVar>;
+function ftv(types: readonly Type[]): Set<TVar>;
+function ftv(schemes: readonly Scheme[]): Set<TVar>;
 function ftv(constraint: Constraint): Set<TVar>; // special case of Type[]
 function ftv(env: Env): Set<TVar>;
 function ftv(a: any): any {
@@ -154,7 +154,7 @@ export const inferExpr = (env: Env, expr: Expr): Scheme => {
 export const constraintsExpr = (
   env: Env,
   expr: Expr
-): [Constraint[], Subst, Type, Scheme] => {
+): readonly [readonly Constraint[], Subst, Type, Scheme] => {
   const initCtx: Context = {
     env: env,
     state: { count: 0 },
@@ -170,7 +170,7 @@ const closeOver = (t: Type): Scheme => {
   return normalize(generalize(emptyEnv, t));
 };
 
-const lookup = (a: TVar, entries: [TVar, TVar][]): TVar | null => {
+const lookup = (a: TVar, entries: readonly [TVar, TVar][]): TVar | null => {
   for (const [k, v] of entries) {
     // TODO: replace with IDs and generate names when printin
     if (a.name === k.name) {
@@ -181,7 +181,7 @@ const lookup = (a: TVar, entries: [TVar, TVar][]): TVar | null => {
 };
 
 // remove duplicates from the array
-function nub(array: TVar[]): TVar[] {
+function nub(array: readonly TVar[]): readonly TVar[] {
   const names: string[] = [];
   return array.filter((tv) => {
     if (!names.includes(tv.name)) {
@@ -198,7 +198,7 @@ function nub(array: TVar[]): TVar[] {
 // Renames type variables so that they start with 'a' and there are no gaps
 const normalize = (sc: Scheme): Scheme => {
   // Returns the names of the free variables in a type
-  const fv = (type: Type): TVar[] => {
+  const fv = (type: Type): readonly TVar[] => {
     switch (type.tag) {
       case "TVar":
         return [type];
@@ -336,7 +336,7 @@ const ops = (op: Binop): Type => {
   }
 };
 
-const infer = (expr: Expr, ctx: Context): [Type, Constraint[]] => {
+const infer = (expr: Expr, ctx: Context): readonly [Type, readonly Constraint[]] => {
   switch (expr.tag) {
     case "Lit": {
       const lit = expr.value;
@@ -374,7 +374,7 @@ const infer = (expr: Expr, ctx: Context): [Type, Constraint[]] => {
       const { fn, args } = expr;
       const [t_fn, c_fn] = infer(fn, ctx);
       const t_args: Type[] = [];
-      const c_args: Constraint[][] = [];
+      const c_args: (readonly Constraint[])[] = [];
       for (const arg of args) {
         const [t_arg, c_arg] = infer(arg, ctx);
         t_args.push(t_arg);
@@ -447,11 +447,11 @@ const infer = (expr: Expr, ctx: Context): [Type, Constraint[]] => {
 
 const emptySubst: Subst = Map();
 
-const runSolve = (cs: Constraint[]): Subst => {
+const runSolve = (cs: readonly Constraint[]): Subst => {
   return solver([emptySubst, cs]);
 };
 
-const unifyMany = (ts1: Type[], ts2: Type[]): Subst => {
+const unifyMany = (ts1: readonly Type[], ts2: readonly Type[]): Subst => {
   if (ts1.length !== ts2.length) {
     throw new UnificationMismatch(ts1, ts2);
   }

--- a/write-you-a-haskell/src/type.ts
+++ b/write-you-a-haskell/src/type.ts
@@ -4,17 +4,17 @@ import { zip } from "./util";
 
 // TODO: update types to use id's
 export type TVar = { tag: "TVar"; name: string };
-export type TCon = { tag: "TCon"; name: string; params: Type[] };
+export type TCon = { tag: "TCon"; name: string; params: readonly Type[] };
 export type TApp = {
   tag: "TApp";
-  args: Type[];
+  args: readonly Type[];
   ret: Type;
   src?: "App" | "Fix" | "Lam";
 };
 
 export type Type = TVar | TCon | TApp;
 
-export type Scheme = { tag: "Forall"; qualifiers: TVar[]; type: Type };
+export type Scheme = { tag: "Forall"; qualifiers: readonly TVar[]; type: Type };
 
 export const tInt: TCon = { tag: "TCon", name: "Int", params: [] };
 export const tBool: TCon = { tag: "TCon", name: "Bool", params: [] };
@@ -67,7 +67,7 @@ export function equal(a: Type | Scheme, b: Type | Scheme): boolean {
 // are in scope.
 export type Env = Map<string, Scheme>;
 
-export type Constraint = [Type, Type];
-export type Unifier = [Subst, Constraint[]];
+export type Constraint = readonly [Type, Type];
+export type Unifier = readonly [Subst, readonly Constraint[]];
 
 export type Subst = Map<string, Type>;


### PR DESCRIPTION
This is to avoid accidental mutations.