### PR TITLE
Rename TApp to TFun

### DIFF
--- a/write-you-a-haskell/src/__tests__/infer.test.ts
+++ b/write-you-a-haskell/src/__tests__/infer.test.ts
@@ -475,10 +475,10 @@ describe("inferExpr", () => {
         tag: "Forall",
         qualifiers: [aVar, bVar],
         type: {
-          tag: "TApp",
+          tag: "TFun",
           args: [
             { tag: "TCon", id: 2, name: "Array", params: [aVar] },
-            { tag: "TApp", args: [aVar, tInt], ret: bVar, src: "App" },
+            { tag: "TFun", args: [aVar, tInt], ret: bVar, src: "App" },
           ],
           ret: { tag: "TCon", id: 3, name: "Array", params: [bVar] },
         },
@@ -514,10 +514,10 @@ describe("inferExpr", () => {
         tag: "Forall",
         qualifiers: [aVar, bVar],
         type: {
-          tag: "TApp",
+          tag: "TFun",
           args: [
             { tag: "TCon", id: 3, name: "Array", params: [aVar] },
-            { tag: "TApp", args: [aVar, tInt], ret: bVar, src: "App" },
+            { tag: "TFun", args: [aVar, tInt], ret: bVar, src: "App" },
           ],
           ret: { tag: "TCon", id: 4, name: "Array", params: [bVar] },
         },
@@ -557,7 +557,7 @@ describe("inferExpr", () => {
         tag: "Forall",
         qualifiers: [aVar],
         type: {
-          tag: "TApp",
+          tag: "TFun",
           args: [aVar],
           ret: { tag: "TCon", id: 1, name: "Promise", params: [aVar] },
           src: "Lam",
@@ -583,7 +583,7 @@ describe("inferExpr", () => {
         tag: "Forall",
         qualifiers: [aVar],
         type: {
-          tag: "TApp",
+          tag: "TFun",
           args: [{ tag: "TCon", id: 2, name: "Foo", params: [aVar] }],
           ret: aVar,
           src: "Lam",
@@ -613,7 +613,7 @@ describe("inferExpr", () => {
         tag: "Forall",
         qualifiers: [aVar],
         type: {
-          tag: "TApp",
+          tag: "TFun",
           args: [{ tag: "TCon", id: 1, name: "Foo", params: [aVar] }],
           ret: aVar,
           src: "Lam",
@@ -651,7 +651,7 @@ describe("inferExpr", () => {
         tag: "Forall",
         qualifiers: [aVar, bVar],
         type: {
-          tag: "TApp",
+          tag: "TFun",
           args: [aVar, bVar],
           ret: { tag: "TUnion", types: [aVar, bVar] },
         },

--- a/write-you-a-haskell/src/constraint-solver.ts
+++ b/write-you-a-haskell/src/constraint-solver.ts
@@ -1,7 +1,7 @@
 import { Map } from "immutable";
 
 import { Type, TVar, Subst, Constraint, Unifier, equal, TUnion } from "./type";
-import { isTCon, isTVar, isTApp, isTUnion } from "./type";
+import { isTCon, isTVar, isTFun, isTUnion } from "./type";
 import { InfiniteType, UnificationFail, UnificationMismatch } from "./errors";
 import { apply, ftv } from "./util";
 
@@ -36,17 +36,17 @@ export const unifies = (t1: Type, t2: Type): Subst => {
     return bind(t1, t2);
   } else if (isTVar(t2)) {
     return bind(t2, t1);
-  } else if (isTApp(t1) && isTApp(t2)) {
+  } else if (isTFun(t1) && isTFun(t2)) {
     // infer() only ever creates a Lam node on the left side of a constraint
     // and an App on the right side of a constraint so this check is sufficient.
     if (t1.src === "Lam" && t2.src === "App") {
       // partial application
       if (t1.args.length > t2.args.length) {
         const t1_partial: Type = {
-          tag: "TApp",
+          tag: "TFun",
           args: t1.args.slice(0, t2.args.length),
           ret: {
-            tag: "TApp",
+            tag: "TFun",
             args: t1.args.slice(t2.args.length),
             ret: t1.ret,
           },
@@ -63,7 +63,7 @@ export const unifies = (t1: Type, t2: Type): Subst => {
       // TODO: update this once we support rest params
       if (t1.args.length < t2.args.length) {
         const t2_without_extra_args: Type = {
-          tag: "TApp",
+          tag: "TFun",
           args: t2.args.slice(0, t1.args.length),
           ret: t2.ret,
           src: t2.src,
@@ -84,7 +84,7 @@ export const unifies = (t1: Type, t2: Type): Subst => {
       // TODO: update this once we support rest params
       if (t1.args.length > t2.args.length) {
         const t1_without_extra_args: Type = {
-          tag: "TApp",
+          tag: "TFun",
           args: t1.args.slice(0, t2.args.length),
           ret: t1.ret,
           src: t1.src,

--- a/write-you-a-haskell/src/infer.ts
+++ b/write-you-a-haskell/src/infer.ts
@@ -72,7 +72,7 @@ const normalize = (sc: Scheme): Scheme => {
     switch (type.tag) {
       case "TVar":
         return [type];
-      case "TApp":
+      case "TFun":
         return [...type.args.flatMap(fv), ...fv(type.ret)];
       case "TCon":
         return [];
@@ -92,10 +92,10 @@ const normalize = (sc: Scheme): Scheme => {
 
   const normType = (type: Type): Type => {
     switch (type.tag) {
-      case "TApp": {
+      case "TFun": {
         const { args, ret, src } = type;
         return {
-          tag: "TApp",
+          tag: "TFun",
           args: args.map(normType),
           ret: normType(ret),
           src,
@@ -209,7 +209,7 @@ const infer = (
         }),
       };
       const [t, c] = infer(body, newCtx);
-      return [{ tag: "TApp", args: tvs, ret: t, src: "Lam" }, c];
+      return [{ tag: "TFun", args: tvs, ret: t, src: "Lam" }, c];
     }
 
     case "App": {
@@ -229,7 +229,7 @@ const infer = (
           ...c_fn,
           ...c_args.flat(),
           // This is almost the reverse of what we return from the "Lam" case
-          [t_fn, { tag: "TApp", args: t_args, ret: tv, src: "App" }],
+          [t_fn, { tag: "TFun", args: t_args, ret: tv, src: "App" }],
         ],
       ];
     }
@@ -254,7 +254,7 @@ const infer = (
       const tv = fresh(ctx);
       return [
         tv,
-        [...c1, [{ tag: "TApp", args: [tv], ret: tv, src: "Fix" }, t1]],
+        [...c1, [{ tag: "TFun", args: [tv], ret: tv, src: "Fix" }, t1]],
       ];
     }
 
@@ -264,7 +264,7 @@ const infer = (
       const [rt, rc] = infer(right, ctx);
       const tv = fresh(ctx);
       const u1: Type = {
-        tag: "TApp",
+        tag: "TFun",
         args: [lt, rt],
         ret: tv,
       };
@@ -287,25 +287,25 @@ const ops = (op: Binop): Type => {
   switch (op) {
     case "Add":
       return {
-        tag: "TApp",
+        tag: "TFun",
         args: [tInt, tInt],
         ret: tInt,
       };
     case "Mul":
       return {
-        tag: "TApp",
+        tag: "TFun",
         args: [tInt, tInt],
         ret: tInt,
       };
     case "Sub":
       return {
-        tag: "TApp",
+        tag: "TFun",
         args: [tInt, tInt],
         ret: tInt,
       };
     case "Eql":
       return {
-        tag: "TApp",
+        tag: "TFun",
         args: [tInt, tInt],
         ret: tBool,
       };

--- a/write-you-a-haskell/src/type.ts
+++ b/write-you-a-haskell/src/type.ts
@@ -16,15 +16,15 @@ export type TCon = TCommon & {
   name: string;
   params: readonly Type[];
 };
-export type TApp = TCommon & {
-  tag: "TApp";
+export type TFun = TCommon & {
+  tag: "TFun";
   args: readonly Type[];
   ret: Type;
   src?: "App" | "Fix" | "Lam";
 };
 export type TUnion = TCommon & { tag: "TUnion"; types: Type[] };
 
-export type Type = TVar | TCon | TApp | TUnion;
+export type Type = TVar | TCon | TFun | TUnion;
 
 export type Scheme = { tag: "Forall"; qualifiers: readonly TVar[]; type: Type };
 
@@ -40,7 +40,7 @@ export function print(t: Type | Scheme): string {
       const params = t.params.map(print).join(", ");
       return t.params.length > 0 ? `${t.name}<${params}>` : t.name;
     }
-    case "TApp": {
+    case "TFun": {
       return `(${t.args.map(print).join(", ")}) => ${print(t.ret)}`;
     }
     case "TUnion": {
@@ -65,7 +65,7 @@ export function equal(a: Type | Scheme, b: Type | Scheme): boolean {
       a.params.length === b.params.length &&
       zip(a.params, b.params).every((pair) => equal(...pair))
     );
-  } else if (a.tag === "TApp" && b.tag === "TApp") {
+  } else if (a.tag === "TFun" && b.tag === "TFun") {
     return (
       a.args.length === b.args.length &&
       zip([...a.args, a.ret], [...b.args, b.ret]).every((pair) =>
@@ -82,7 +82,7 @@ export function equal(a: Type | Scheme, b: Type | Scheme): boolean {
 export function freeze(t: Type): void {
   t.frozen = true;
   switch (t.tag) {
-    case "TApp": {
+    case "TFun": {
       t.args.map(freeze);
       freeze(t.ret);
       break;
@@ -114,7 +114,7 @@ export const scheme = (qualifiers: readonly TVar[], type: Type): Scheme => {
 
 export const isTCon = (t: Type): t is TCon => t.tag === "TCon";
 export const isTVar = (t: Type): t is TVar => t.tag === "TVar";
-export const isTApp = (t: Type): t is TApp => t.tag === "TApp";
+export const isTFun = (t: Type): t is TFun => t.tag === "TFun";
 export const isTUnion = (t: Type): t is TUnion => t.tag === "TUnion";
 export const isScheme = (t: any): t is Scheme => t.tag === "Forall";
 

--- a/write-you-a-haskell/src/util.ts
+++ b/write-you-a-haskell/src/util.ts
@@ -1,7 +1,7 @@
 import { Map, Set } from "immutable";
 
 import { Type, TCon, TVar, Subst, Constraint, Scheme, Env } from "./type";
-import { isTCon, isTVar, isTApp, isTUnion, isScheme, scheme } from "./type";
+import { isTCon, isTVar, isTFun, isTUnion, isScheme, scheme } from "./type";
 
 export function apply(s: Subst, type: Type): Type;
 export function apply(s: Subst, scheme: Scheme): Scheme;
@@ -28,7 +28,7 @@ export function apply(s: Subst, a: any): any {
   if (isTVar(a)) {
     return s.get(a.id) || a;
   }
-  if (isTApp(a)) {
+  if (isTFun(a)) {
     return {
       ...a,
       args: apply(s, a.args),
@@ -85,7 +85,7 @@ export function ftv(a: any): any {
   if (isTVar(a)) {
     return Set([a]); // Set.singleton a
   }
-  if (isTApp(a)) {
+  if (isTFun(a)) {
     return Set.union([...a.args.map(ftv), ftv(a.ret)]); // ftv t1 `Set.union` ftv t2
   }
   if (isTUnion(a)) {


### PR DESCRIPTION
The reason for this rename is that we were generating `TApp` types from `App` and `Lam` nodes which may lead to confusion between `TApp` and `App`.  Originally the type was called `TArr` which didn't have this problem, but I found it hard to remember what `TArr` was meant to represent whereas `TFun` clicks with me.