### PR TITLE
Improve inference and handling of union types

### DIFF
--- a/write-you-a-haskell/README.md
+++ b/write-you-a-haskell/README.md
@@ -8,3 +8,17 @@ https://github.com/sdiehl/write-you-a-haskell/blob/master/chapter7/poly_constrai
 281 lines (not including helper files)
 
 After that, tackle thih.
+
+
+## Notes
+
+Destructuring:
+- `let Promise<a> = foo()`, should this desugar to `const a = await foo()`?
+- What about other type constructors, e.g. `Maybe<a>` or `Pair<a, b>`?
+  - `Maybe<a>` can be either `Some<a>` or `None` so `Maybe<a>` is not a
+    type constructor, but actually a parametric type
+    - How do we differentiat `Maybe<a>` from `Some<a>`?
+    - It seems like `Promise<a>` is also a pametric type and not a type
+      constructor
+- We should probably introduce tuple and record types to support destructuring
+  

--- a/write-you-a-haskell/src/__tests__/function.test.ts
+++ b/write-you-a-haskell/src/__tests__/function.test.ts
@@ -295,11 +295,12 @@ describe("function subtyping", () => {
       qualifiers: [aVar, bVar],
       type: {
         tag: "TFun",
+        id: 2,
         args: [
-          { tag: "TCon", id: 2, name: "Array", params: [aVar] },
-          { tag: "TFun", args: [aVar, tInt], ret: bVar, src: "App" },
+          { tag: "TCon", id: 3, name: "Array", params: [aVar] },
+          { tag: "TFun", id: 4, args: [aVar, tInt], ret: bVar, src: "App" },
         ],
-        ret: { tag: "TCon", id: 3, name: "Array", params: [bVar] },
+        ret: { tag: "TCon", id: 5, name: "Array", params: [bVar] },
       },
     };
 
@@ -309,7 +310,7 @@ describe("function subtyping", () => {
     const intArray: Scheme = {
       tag: "Forall",
       qualifiers: [],
-      type: { tag: "TCon", id: 4, name: "Array", params: [tInt] },
+      type: { tag: "TCon", id: 6, name: "Array", params: [tInt] },
     };
 
     env = env.set("array", intArray);
@@ -334,11 +335,12 @@ describe("function subtyping", () => {
       qualifiers: [aVar, bVar],
       type: {
         tag: "TFun",
+        id: 3,
         args: [
-          { tag: "TCon", id: 3, name: "Array", params: [aVar] },
-          { tag: "TFun", args: [aVar, tInt], ret: bVar, src: "App" },
+          { tag: "TCon", id: 4, name: "Array", params: [aVar] },
+          { tag: "TFun", id: 5, args: [aVar, tInt], ret: bVar, src: "App" },
         ],
-        ret: { tag: "TCon", id: 4, name: "Array", params: [bVar] },
+        ret: { tag: "TCon", id: 6, name: "Array", params: [bVar] },
       },
     };
 
@@ -348,7 +350,7 @@ describe("function subtyping", () => {
     const intArray: Scheme = {
       tag: "Forall",
       qualifiers: [],
-      type: { tag: "TCon", id: 5, name: "Array", params: [tInt] },
+      type: { tag: "TCon", id: 7, name: "Array", params: [tInt] },
     };
 
     env = env.set("array", intArray);
@@ -368,7 +370,7 @@ describe("function subtyping", () => {
       ],
     };
 
-    const result = inferExpr(env, call, { count: 6 });
+    const result = inferExpr(env, call, { count: 8 });
 
     expect(print(result)).toEqual("Array<(Int) => Int>");
   });

--- a/write-you-a-haskell/src/__tests__/infer.test.ts
+++ b/write-you-a-haskell/src/__tests__/infer.test.ts
@@ -183,8 +183,9 @@ describe("inferExpr", () => {
         qualifiers: [aVar],
         type: {
           tag: "TFun",
+          id: 1,
           args: [aVar],
-          ret: { tag: "TCon", id: 1, name: "Promise", params: [aVar] },
+          ret: { tag: "TCon", id: 2, name: "Promise", params: [aVar] },
           src: "Lam",
         },
       };
@@ -193,14 +194,14 @@ describe("inferExpr", () => {
 
       env = env.set("promisify", promisifyScheme);
       const intCall: Binding = ["call", b.app(b._var("promisify"), [b.int(5)])];
-      const intResult = inferExpr(env, intCall[1], { count: 2 });
+      const intResult = inferExpr(env, intCall[1], { count: 3 });
       expect(print(intResult)).toEqual("Promise<Int>");
 
       const boolCall: Binding = [
         "call",
         b.app(b._var("promisify"), [b.bool(true)]),
       ];
-      const boolResult = inferExpr(env, boolCall[1], { count: 2 });
+      const boolResult = inferExpr(env, boolCall[1], { count: 3 });
       expect(print(boolResult)).toEqual("Promise<Bool>");
     });
 
@@ -212,6 +213,7 @@ describe("inferExpr", () => {
         qualifiers: [aVar],
         type: {
           tag: "TFun",
+          id: 1,
           args: [{ tag: "TCon", id: 2, name: "Foo", params: [aVar] }],
           ret: aVar,
           src: "Lam",
@@ -242,7 +244,8 @@ describe("inferExpr", () => {
         qualifiers: [aVar],
         type: {
           tag: "TFun",
-          args: [{ tag: "TCon", id: 1, name: "Foo", params: [aVar] }],
+          id: 1,
+          args: [{ tag: "TCon", id: 2, name: "Foo", params: [aVar] }],
           ret: aVar,
           src: "Lam",
         },
@@ -257,15 +260,15 @@ describe("inferExpr", () => {
         qualifiers: [],
         type: {
           tag: "TCon",
-          id: 2,
+          id: 3,
           name: "Foo",
-          params: [{ tag: "TCon", id: 3, name: "Int", params: [] }],
+          params: [{ tag: "TCon", id: 4, name: "Int", params: [] }],
         },
       });
 
       const extractedX = b.app(b._var("extract"), [b._var("x")]);
 
-      const result = inferExpr(env, extractedX, { count: 4 });
+      const result = inferExpr(env, extractedX, { count: 5 });
       expect(print(result)).toEqual("Int");
     });
   });

--- a/write-you-a-haskell/src/__tests__/union.test.ts
+++ b/write-you-a-haskell/src/__tests__/union.test.ts
@@ -73,9 +73,7 @@ describe("Union types and type widening", () => {
     expect(print(result)).toEqual("<a>(Bool, (Int | Bool) => a) => a");
   });
 
-  test("infer union of function types", () => {
-    const int: TCon = { tag: "TCon", id: 0, name: "Int", params: [] };
-    const bool: TCon = { tag: "TCon", id: 1, name: "Bool", params: [] };
+  test.only("infer union of function types", () => {
     const foo: Scheme = {
       tag: "Forall",
       qualifiers: [],
@@ -109,8 +107,8 @@ describe("Union types and type widening", () => {
     env = env.set("foo", foo);
     env = env.set("bar", bar);
 
-    const result = inferExpr(env, expr, {count: 4});
-    expect(print(result)).toMatchInlineSnapshot(`"(Bool | Int) => (Int | Bool) => Bool | Int"`)
+    const result = inferExpr(env, expr, {count: 6});
+    expect(print(result)).toMatchInlineSnapshot(`"(Bool) => (Int | Bool) => Bool | Int"`)
   });
 
   test("widen existing union type", () => {

--- a/write-you-a-haskell/src/__tests__/union.test.ts
+++ b/write-you-a-haskell/src/__tests__/union.test.ts
@@ -1,8 +1,8 @@
 import { Map } from "immutable";
 
-import { inferExpr } from "../infer";
+import { inferExpr, constraintsExpr } from "../infer";
 import { Expr } from "../syntax-types";
-import { Env, print, Scheme, TVar } from "../type";
+import { Env, print, Scheme, TVar, TCon, TFun } from "../type";
 import * as b from "../syntax-builders";
 
 type Binding = [string, Expr];
@@ -17,8 +17,9 @@ describe("Union types and type widening", () => {
       qualifiers: [aVar, bVar],
       type: {
         tag: "TFun",
+        id: 2,
         args: [aVar, bVar],
-        ret: { tag: "TUnion", types: [aVar, bVar] },
+        ret: { tag: "TUnion", id: 3, types: [aVar, bVar] },
       },
     };
 
@@ -37,7 +38,7 @@ describe("Union types and type widening", () => {
     }
     expect(print(result0)).toEqual("<a, b>(a, b) => a | b");
 
-    const result1 = inferExpr(env, call, { count: 2 });
+    const result1 = inferExpr(env, call, { count: 4 });
 
     expect(print(result1)).toEqual("Int | Bool");
 
@@ -48,11 +49,12 @@ describe("Union types and type widening", () => {
     };
 
     env = env.set("retUnion", retUnion);
-    const result2 = inferExpr(env, call2, { count: 2 });
+    const result2 = inferExpr(env, call2, { count: 4 });
 
     expect(print(result2)).toEqual("Bool | Int");
   });
 
+  // TODO: figure out a way to normalize union types.
   test.todo("order of types in union doesn't matter");
 
   test("infer lambda with union return type", () => {
@@ -69,6 +71,100 @@ describe("Union types and type widening", () => {
 
     const result = inferExpr(env, expr);
     expect(print(result)).toEqual("<a>(Bool, (Int | Bool) => a) => a");
+  });
+
+  test("infer union of function types", () => {
+    const int: TCon = { tag: "TCon", id: 0, name: "Int", params: [] };
+    const bool: TCon = { tag: "TCon", id: 1, name: "Bool", params: [] };
+    const foo: Scheme = {
+      tag: "Forall",
+      qualifiers: [],
+      type: {
+        tag: "TFun",
+        id: 0,
+        args: [{ tag: "TCon", id: 1, name: "Int", params: [] }],
+        ret: { tag: "TCon", id: 2, name: "Bool", params: [] },
+      },
+    };
+    const bar: Scheme = {
+      tag: "Forall",
+      qualifiers: [],
+      type: {
+        tag: "TFun",
+        id: 3,
+        args: [{ tag: "TCon", id: 4, name: "Bool", params: [] }],
+        ret: { tag: "TCon", id: 5, name: "Int", params: [] },
+      },
+    };
+    const expr: Expr = b.lam(
+      ["x"],
+      b._if(
+        b._var("x"),
+        b._var("foo"),
+        b._var("bar"),
+      )
+    );
+
+    let env: Env = Map();
+    env = env.set("foo", foo);
+    env = env.set("bar", bar);
+
+    const result = inferExpr(env, expr, {count: 4});
+    expect(print(result)).toMatchInlineSnapshot(`"(Bool | Int) => (Int | Bool) => Bool | Int"`)
+  });
+
+  test("widen existing union type", () => {
+    const int: TCon = { tag: "TCon", id: 0, name: "Int", params: [] };
+    const bool: TCon = { tag: "TCon", id: 1, name: "Bool", params: [] };
+
+    const union: Scheme = {
+      tag: "Forall",
+      qualifiers: [],
+      type: {
+        tag: "TUnion",
+        id: 2,
+        types: [int, bool],
+      },
+    };
+
+    let env: Env = Map();
+    env = env.set("union", union);
+
+    const expr: Expr = b.lam(
+      ["x", "y"],
+      b._if(
+        b._var("x"),
+        b.app(b._var("y"), [b._var("union")]),
+        b.app(b._var("y"), [b.str("hello")])
+      )
+    );
+
+    const result = inferExpr(env, expr);
+    expect(print(result)).toEqual("<a>(Bool, Int | Bool | Str) => a");
+  });
+
+  test("widen inferred union type", () => {
+    const expr: Expr = b.lam(
+      ["x"],
+      b._let(
+        "a",
+        b.app(b._var("x"), [b.int(5)]),
+        b._let(
+          "b",
+          b.app(b._var("x"), [b.bool(true)]),
+          b._let(
+            "c",
+            b.app(b._var("x"), [b.str("hello")]),
+            b._var("c"),
+          ),
+        ),
+      ),
+    );
+
+    const env: Env = Map();
+    const result = inferExpr(env, expr);
+
+    expect(print(result)).toEqual("<a>((Int | Bool | Str) => a) => a");
   });
 
   test("should not widen frozen types", () => {

--- a/write-you-a-haskell/src/__tests__/union.test.ts
+++ b/write-you-a-haskell/src/__tests__/union.test.ts
@@ -73,7 +73,7 @@ describe("Union types and type widening", () => {
     expect(print(result)).toEqual("<a>(Bool, (Int | Bool) => a) => a");
   });
 
-  test.only("infer union of function types", () => {
+  test("infer union of function types", () => {
     const foo: Scheme = {
       tag: "Forall",
       qualifiers: [],

--- a/write-you-a-haskell/src/constraint-solver.ts
+++ b/write-you-a-haskell/src/constraint-solver.ts
@@ -121,14 +121,14 @@ export const unifies = (t1: Type, t2: Type, ctx: Context): Subst => {
     if ("id" in t1 && "id" in t2 && !t1.frozen && !t2.frozen) {
       ctx.state.count++;
       const names: string[] = [];
-      // flatten
+      // Flattens types
       const types = [
         ...(isTUnion(t1) ? t1.types : [t1]),
         ...(isTUnion(t2) ? t2.types : [t2]),
       ].filter(type => {
-        // remove duplicate TCons
-        // TODO: check for TCon's with different numbers of params
-        if (isTCon(type)) {
+        // Removes duplicate TCons
+        // TODO: handle TCons with params
+        if (isTCon(type) && type.params.length === 0) {
           if (names.includes(type.name)) {
             return false;
           }

--- a/write-you-a-haskell/src/constraint-solver.ts
+++ b/write-you-a-haskell/src/constraint-solver.ts
@@ -1,6 +1,6 @@
 import { Map } from "immutable";
 
-import { Type, TVar, Subst, Constraint, Unifier, equal, TUnion } from "./type";
+import { Type, TVar, Subst, Constraint, Unifier, equal, TUnion, Context } from "./type";
 import { isTCon, isTVar, isTFun, isTUnion } from "./type";
 import { InfiniteType, UnificationFail, UnificationMismatch } from "./errors";
 import { apply, ftv } from "./util";
@@ -11,11 +11,11 @@ import { apply, ftv } from "./util";
 
 const emptySubst: Subst = Map();
 
-export const runSolve = (cs: readonly Constraint[]): Subst => {
-  return solver([emptySubst, cs]);
+export const runSolve = (cs: readonly Constraint[], ctx: Context): Subst => {
+  return solver([emptySubst, cs], ctx);
 };
 
-const unifyMany = (ts1: readonly Type[], ts2: readonly Type[]): Subst => {
+const unifyMany = (ts1: readonly Type[], ts2: readonly Type[], ctx: Context): Subst => {
   if (ts1.length !== ts2.length) {
     throw new UnificationMismatch(ts1, ts2);
   }
@@ -24,12 +24,12 @@ const unifyMany = (ts1: readonly Type[], ts2: readonly Type[]): Subst => {
   }
   const [t1, ...rest1] = ts1;
   const [t2, ...rest2] = ts2;
-  const su1 = unifies(t1, t2);
-  const su2 = unifyMany(apply(su1, rest1), apply(su1, rest2));
+  const su1 = unifies(t1, t2, ctx);
+  const su2 = unifyMany(apply(su1, rest1), apply(su1, rest2), ctx);
   return composeSubs(su2, su1);
 };
 
-export const unifies = (t1: Type, t2: Type): Subst => {
+export const unifies = (t1: Type, t2: Type, ctx: Context): Subst => {
   if (equal(t1, t2)) {
     return emptySubst;
   } else if (isTVar(t1)) {
@@ -42,11 +42,14 @@ export const unifies = (t1: Type, t2: Type): Subst => {
     if (t1.src === "Lam" && t2.src === "App") {
       // partial application
       if (t1.args.length > t2.args.length) {
+        ctx.state.count++;
         const t1_partial: Type = {
           tag: "TFun",
+          id: t1.id, // is it safe to reuse `id` here?
           args: t1.args.slice(0, t2.args.length),
           ret: {
             tag: "TFun",
+            id: ctx.state.count,
             args: t1.args.slice(t2.args.length),
             ret: t1.ret,
           },
@@ -54,7 +57,8 @@ export const unifies = (t1: Type, t2: Type): Subst => {
         };
         return unifyMany(
           [...t1_partial.args, t1_partial.ret],
-          [...t2.args, t2.ret]
+          [...t2.args, t2.ret],
+          ctx
         );
       }
 
@@ -64,13 +68,15 @@ export const unifies = (t1: Type, t2: Type): Subst => {
       if (t1.args.length < t2.args.length) {
         const t2_without_extra_args: Type = {
           tag: "TFun",
+          id: t2.id, // is it safe to reuse `id` here?
           args: t2.args.slice(0, t1.args.length),
           ret: t2.ret,
           src: t2.src,
         };
         return unifyMany(
           [...t1.args, t1.ret],
-          [...t2_without_extra_args.args, t2_without_extra_args.ret]
+          [...t2_without_extra_args.args, t2_without_extra_args.ret],
+          ctx
         );
       }
     }
@@ -85,36 +91,55 @@ export const unifies = (t1: Type, t2: Type): Subst => {
       if (t1.args.length > t2.args.length) {
         const t1_without_extra_args: Type = {
           tag: "TFun",
+          id: t1.id, // is it safe to reuse `id` here?
           args: t1.args.slice(0, t2.args.length),
           ret: t1.ret,
           src: t1.src,
         };
         return unifyMany(
           [...t1_without_extra_args.args, t1_without_extra_args.ret],
-          [...t2.args, t2.ret]
+          [...t2.args, t2.ret],
+          ctx
         );
       }
     }
 
     // TODO: add support for optional params
     // we can model optional params as union types, e.g. int | void
-
-    return unifyMany([...t1.args, t1.ret], [...t2.args, t2.ret]);
+    return unifyMany([...t1.args, t1.ret], [...t2.args, t2.ret], ctx);
   } else if (isTCon(t1) && isTCon(t2) && t1.name === t2.name) {
-    return unifyMany(t1.params, t2.params);
+    return unifyMany(t1.params, t2.params, ctx);
   } else if (isTUnion(t1) && isTUnion(t2)) {
     // Assume that the union types have been normalized by this point
     // This only works if the types that make up the unions are ordered
     // consistently.  Is there a way to do this?
-    return unifyMany(t1.types, t2.types);
+    return unifyMany(t1.types, t2.types, ctx);
   } else {
     // As long as the types haven't been frozen then this is okay
     // NOTE: We may need to add .src info in the future if we notice
     // any places where expected type widening is occurring.
     if ("id" in t1 && "id" in t2 && !t1.frozen && !t2.frozen) {
+      ctx.state.count++;
+      const names: string[] = [];
+      // flatten
+      const types = [
+        ...(isTUnion(t1) ? t1.types : [t1]),
+        ...(isTUnion(t2) ? t2.types : [t2]),
+      ].filter(type => {
+        // remove duplicate TCons
+        // TODO: check for TCon's with different numbers of params
+        if (isTCon(type)) {
+          if (names.includes(type.name)) {
+            return false;
+          }
+          names.push(type.name);
+        }
+        return true;
+      });
       const union: TUnion = {
         tag: "TUnion",
-        types: [t1, t2],
+        id: ctx.state.count,
+        types,
       };
       const result: Subst = Map([
         [t1.id, union],
@@ -132,14 +157,14 @@ const composeSubs = (s1: Subst, s2: Subst): Subst => {
 };
 
 // Unification solver
-const solver = (u: Unifier): Subst => {
+const solver = (u: Unifier, ctx: Context): Subst => {
   const [su, cs] = u;
   if (cs.length === 0) {
     return su;
   }
   const [[t1, t2], ...cs0] = cs;
-  const su1 = unifies(t1, t2);
-  return solver([composeSubs(su1, su), apply(su1, cs0)]);
+  const su1 = unifies(t1, t2, ctx);
+  return solver([composeSubs(su1, su), apply(su1, cs0)], ctx);
 };
 
 const bind = (tv: TVar, t: Type): Subst => {

--- a/write-you-a-haskell/src/infer.ts
+++ b/write-you-a-haskell/src/infer.ts
@@ -2,20 +2,10 @@ import { Map } from "immutable";
 
 import { UnboundVariable } from "./errors";
 import { freeze, scheme, tBool, tInt } from "./type";
-import { Constraint, Env, Scheme, Subst, TCon, TVar, Type } from "./type";
+import { Constraint, Env, Scheme, Subst, TCon, TVar, Type, Context, State } from "./type";
 import { Binop, Expr } from "./syntax-types";
 import { zip, apply, ftv, assertUnreachable } from "./util";
 import { runSolve } from "./constraint-solver";
-
-type State = {
-  count: number;
-};
-
-type Context = {
-  env: Env;
-  state: State;
-  async?: boolean;
-};
 
 const emptyEnv: Env = Map();
 
@@ -25,7 +15,7 @@ export const inferExpr = (env: Env, expr: Expr, state?: State): Scheme => {
     state: state || { count: 0 },
   };
   const [ty, cs] = infer(expr, initCtx);
-  const subs = runSolve(cs);
+  const subs = runSolve(cs, initCtx);
   return closeOver(apply(subs, ty));
 };
 
@@ -39,7 +29,7 @@ export const constraintsExpr = (
     state: { count: 0 },
   };
   const [ty, cs] = infer(expr, initCtx);
-  const subst = runSolve(cs);
+  const subst = runSolve(cs, initCtx);
   const sc = closeOver(apply(subst, ty));
   return [cs, subst, ty, sc];
 };
@@ -54,7 +44,7 @@ const closeOver = (t: Type): Scheme => {
 };
 
 // remove duplicates from the array
-function nub(array: readonly TVar[]): readonly TVar[] {
+function nub<T extends {id: number}>(array: readonly T[]): readonly T[] {
   const ids: number[] = [];
   return array.filter((tv) => {
     if (!ids.includes(tv.id)) {
@@ -94,12 +84,11 @@ const normalize = (sc: Scheme): Scheme => {
   const normType = (type: Type): Type => {
     switch (type.tag) {
       case "TFun": {
-        const { args, ret, src } = type;
+        const { args, ret } = type;
         return {
-          tag: "TFun",
+          ...type,
           args: args.map(normType),
           ret: normType(ret),
-          src,
         };
       }
       case "TCon":
@@ -117,7 +106,7 @@ const normalize = (sc: Scheme): Scheme => {
       }
       case "TUnion": {
         return {
-          tag: "TUnion",
+          ...type,
           types: type.types.map(normType),
         };
       }
@@ -191,6 +180,8 @@ const infer = (
           return [freshTCon(ctx, "Int"), []];
         case "LBool":
           return [freshTCon(ctx, "Bool"), []];
+        case "LStr":
+          return [freshTCon(ctx, "Str"), []];
       }
     }
 
@@ -220,7 +211,9 @@ const infer = (
       // TODO: add more general support for conditional types
       const ret = !expr.async || t.tag === "TCon" && t.name === "Promise"
         ? t : freshTCon(ctx, "Promise", [t]);
-      return [{ tag: "TFun", args: tvs, ret, src: "Lam" }, c];
+
+      ctx.state.count++;
+      return [{ tag: "TFun", id: ctx.state.count, args: tvs, ret, src: "Lam" }, c];
     }
 
     case "App": {
@@ -234,13 +227,14 @@ const infer = (
         c_args.push(c_arg);
       }
       const tv = fresh(ctx);
+      ctx.state.count++;
       return [
         tv,
         [
           ...c_fn,
           ...c_args.flat(),
           // This is almost the reverse of what we return from the "Lam" case
-          [t_fn, { tag: "TFun", args: t_args, ret: tv, src: "App" }],
+          [t_fn, { tag: "TFun", id: ctx.state.count, args: t_args, ret: tv, src: "App" }],
         ],
       ];
     }
@@ -249,7 +243,7 @@ const infer = (
       const { name, value, body } = expr;
       const { env } = ctx;
       const [t1, c1] = infer(value, ctx);
-      const subs = runSolve(c1);
+      const subs = runSolve(c1, ctx);
       const sc = generalize(apply(subs, env), apply(subs, t1));
       // (t2, c2) <- inEnv (x, sc) $ local (apply sub) (infer e2)
       const newCtx = { ...ctx, env: ctx.env.set(name, sc) };
@@ -263,9 +257,10 @@ const infer = (
       const { expr: e } = expr;
       let [t1, c1] = infer(e, ctx);
       const tv = fresh(ctx);
+      ctx.state.count++;
       return [
         tv,
-        [...c1, [{ tag: "TFun", args: [tv], ret: tv, src: "Fix" }, t1]],
+        [...c1, [{ tag: "TFun", id: ctx.state.count, args: [tv], ret: tv, src: "Fix" }, t1]],
       ];
     }
 
@@ -274,8 +269,10 @@ const infer = (
       const [lt, lc] = infer(left, ctx);
       const [rt, rc] = infer(right, ctx);
       const tv = fresh(ctx);
+      ctx.state.count++;
       const u1: Type = {
         tag: "TFun",
+        id: ctx.state.count,
         args: [lt, rt],
         ret: tv,
       };
@@ -289,7 +286,8 @@ const infer = (
       const [t2, c2] = infer(th, ctx);
       const [t3, c3] = infer(el, ctx);
       // This is similar how we'll handle n-ary apply
-      return [t2, [...c1, ...c2, ...c3, [t1, tBool], [t2, t3]]];
+      // Why do we have to do [t2, t3] before [t1, freshTCon(ctx, "Bool")]?
+      return [t2, [...c1, ...c2, ...c3, [t2, t3], [t1, freshTCon(ctx, "Bool")]]];
     }
 
     case "Await": {
@@ -324,24 +322,28 @@ const ops = (op: Binop): Type => {
     case "Add":
       return {
         tag: "TFun",
+        id: -10,
         args: [tInt, tInt],
         ret: tInt,
       };
     case "Mul":
       return {
         tag: "TFun",
+        id: -11,
         args: [tInt, tInt],
         ret: tInt,
       };
     case "Sub":
       return {
         tag: "TFun",
+        id: -12,
         args: [tInt, tInt],
         ret: tInt,
       };
     case "Eql":
       return {
         tag: "TFun",
+        id: -13,
         args: [tInt, tInt],
         ret: tBool,
       };

--- a/write-you-a-haskell/src/infer.ts
+++ b/write-you-a-haskell/src/infer.ts
@@ -286,8 +286,8 @@ const infer = (
       const [t2, c2] = infer(th, ctx);
       const [t3, c3] = infer(el, ctx);
       // This is similar how we'll handle n-ary apply
-      // Why do we have to do [t2, t3] before [t1, freshTCon(ctx, "Bool")]?
-      return [t2, [...c1, ...c2, ...c3, [t2, t3], [t1, freshTCon(ctx, "Bool")]]];
+      const bool = freshTCon(ctx, "Bool");
+      return [t2, [...c1, ...c2, ...c3, [t1, bool], [t2, t3]]];
     }
 
     case "Await": {

--- a/write-you-a-haskell/src/syntax-builders.ts
+++ b/write-you-a-haskell/src/syntax-builders.ts
@@ -31,6 +31,10 @@ export const bool = (value: boolean): Expr => ({
   tag: "Lit",
   value: { tag: "LBool", value },
 });
+export const str = (value: string): Expr => ({
+  tag: "Lit",
+  value: { tag: "LStr", value },
+})
 
 export const add = (left: Expr, right: Expr): Expr => ({
   tag: "Op",

--- a/write-you-a-haskell/src/syntax-types.ts
+++ b/write-you-a-haskell/src/syntax-types.ts
@@ -11,7 +11,8 @@ export type Expr =
 
 export type Lit =
   | { tag: "LInt"; value: number }
-  | { tag: "LBool"; value: boolean };
+  | { tag: "LBool"; value: boolean }
+  | { tag: "LStr"; value: string };
 
 export type Binop = "Add" | "Sub" | "Mul" | "Eql";
 

--- a/write-you-a-haskell/src/type.ts
+++ b/write-you-a-haskell/src/type.ts
@@ -6,24 +6,21 @@ function assertUnreachable(x: never): never {
   throw new Error("Didn't expect to get here");
 }
 
-type TCommon = { frozen?: boolean };
+type TCommon = { frozen?: boolean; id: number };
 
-// TODO: update types to use id's
-export type TVar = TCommon & { tag: "TVar"; id: number; name: string };
+export type TVar = TCommon & { tag: "TVar"; name: string };
 export type TCon = TCommon & {
   tag: "TCon";
-  id: number;
   name: string;
   params: readonly Type[];
 };
 export type TFun = TCommon & {
   tag: "TFun";
-  id: number;
   args: readonly Type[];
   ret: Type;
   src?: "App" | "Fix" | "Lam";
 };
-export type TUnion = TCommon & { tag: "TUnion"; id: number; types: readonly Type[] };
+export type TUnion = TCommon & { tag: "TUnion"; types: readonly Type[] };
 
 export type Type = TVar | TCon | TFun | TUnion;
 

--- a/write-you-a-haskell/src/type.ts
+++ b/write-you-a-haskell/src/type.ts
@@ -18,18 +18,24 @@ export type TCon = TCommon & {
 };
 export type TFun = TCommon & {
   tag: "TFun";
+  id: number;
   args: readonly Type[];
   ret: Type;
   src?: "App" | "Fix" | "Lam";
 };
-export type TUnion = TCommon & { tag: "TUnion"; types: Type[] };
+export type TUnion = TCommon & { tag: "TUnion"; id: number; types: readonly Type[] };
 
 export type Type = TVar | TCon | TFun | TUnion;
 
 export type Scheme = { tag: "Forall"; qualifiers: readonly TVar[]; type: Type };
 
+// TODO: provide a way to declare types as part of the syntax AST
+// We'll need this eventually to support defining bindings to external libraries.
+// It will also help simplify writing tests where we need to define the type of
+// of something that we can't easily infer from an expression.
 export const tInt: TCon = { tag: "TCon", id: -1, name: "Int", params: [] };
 export const tBool: TCon = { tag: "TCon", id: -1, name: "Bool", params: [] };
+export const tStr: TCon = { tag: "TCon", id: -1, name: "Str", params: [] };
 
 export function print(t: Type | Scheme): string {
   switch (t.tag) {
@@ -126,3 +132,13 @@ export type Constraint = readonly [Type, Type];
 export type Unifier = readonly [Subst, readonly Constraint[]];
 
 export type Subst = Map<number, Type>;
+
+export type State = {
+  count: number;
+};
+
+export type Context = {
+  env: Env;
+  state: State;
+  async?: boolean;
+};

--- a/write-you-a-haskell/src/util.ts
+++ b/write-you-a-haskell/src/util.ts
@@ -29,6 +29,9 @@ export function apply(s: Subst, a: any): any {
     return s.get(a.id) || a;
   }
   if (isTFun(a)) {
+    if (a.id && s.has(a.id)) {
+      return s.get(a.id)
+    }
     return {
       ...a,
       args: apply(s, a.args),
@@ -36,6 +39,9 @@ export function apply(s: Subst, a: any): any {
     };
   }
   if (isTUnion(a)) {
+    if (a.id && s.has(a.id)) {
+      return s.get(a.id);
+    }
     return {
       ...a,
       types: apply(s, a.types),


### PR DESCRIPTION
This PR makes the following changes:
- adds `id` to function and union types allowing these types to be widened (in addition to type variables and type constructors)
- flattens union types
- removes duplicate type constructors with no params from union types

I'm punting on better union type deduplication for the time being.