### PR TITLE
[wyah]: simplify constraint solver

### DIFF
--- a/write-you-a-haskell/src/constraint-solver.ts
+++ b/write-you-a-haskell/src/constraint-solver.ts
@@ -6,15 +6,23 @@ import {
   Subst,
   Constraint,
   Unifier,
-  equal,
   TUnion,
   Context,
   isTTuple,
   isTRec,
-  print,
+  TFun,
+  TRec,
+  TTuple,
+  TCon,
 } from "./type-types";
 import { isTCon, isTVar, isTFun, isTUnion } from "./type-types";
-import { InfiniteType, UnificationFail, UnificationMismatch } from "./errors";
+import {
+  InfiniteType,
+  UnificationFail,
+  UnificationMismatch,
+  ExtraProperties,
+  MissingProperties,
+} from "./errors";
 import { apply, ftv } from "./util";
 
 //
@@ -47,189 +55,184 @@ const unifyMany = (
 };
 
 export const unifies = (t1: Type, t2: Type, ctx: Context): Subst => {
-  if (equal(t1, t2)) {
-    return emptySubst;
-  } else if (isTVar(t1)) {
-    return bind(t1, t2);
-  } else if (isTVar(t2)) {
-    return bind(t2, t1);
-  } else if (isTFun(t1) && isTFun(t2)) {
-    // infer() only ever creates a Lam node on the left side of a constraint
-    // and an App on the right side of a constraint so this check is sufficient.
-    if (t1.src === "Lam" && t2.src === "App") {
-      // partial application
-      if (t1.args.length > t2.args.length) {
-        ctx.state.count++;
-        const t1_partial: Type = {
-          tag: "TFun",
-          id: t1.id, // is it safe to reuse `id` here?
-          args: t1.args.slice(0, t2.args.length),
-          ret: {
-            tag: "TFun",
-            id: ctx.state.count,
-            args: t1.args.slice(t2.args.length),
-            ret: t1.ret,
-          },
-          src: t1.src,
-        };
-        return unifyMany(
-          [...t1_partial.args, t1_partial.ret],
-          [...t2.args, t2.ret],
-          ctx
-        );
-      }
-
-      // subtyping: we ignore extra args
-      // TODO: Create a `isSubType` helper function
-      // TODO: update this once we support rest params
-      if (t1.args.length < t2.args.length) {
-        const t2_without_extra_args: Type = {
-          tag: "TFun",
-          id: t2.id, // is it safe to reuse `id` here?
-          args: t2.args.slice(0, t1.args.length),
-          ret: t2.ret,
-          src: t2.src,
-        };
-        return unifyMany(
-          [...t1.args, t1.ret],
-          [...t2_without_extra_args.args, t2_without_extra_args.ret],
-          ctx
-        );
-      }
-    }
-
-    // The reverse can happen when a callback is passed as an arg
-    if (t1.src === "App" && t2.src === "Lam") {
-      // Can partial application happen in this situation?
-
-      // subtyping: we ignore extra args
-      // TODO: Create a `isSubType` helper function
-      // TODO: update this once we support rest params
-      if (t1.args.length > t2.args.length) {
-        const t1_without_extra_args: Type = {
-          tag: "TFun",
-          id: t1.id, // is it safe to reuse `id` here?
-          args: t1.args.slice(0, t2.args.length),
-          ret: t1.ret,
-          src: t1.src,
-        };
-        return unifyMany(
-          [...t1_without_extra_args.args, t1_without_extra_args.ret],
-          [...t2.args, t2.ret],
-          ctx
-        );
-      }
-    }
-
-    // TODO: add support for optional params
-    // we can model optional params as union types, e.g. int | void
-    return unifyMany([...t1.args, t1.ret], [...t2.args, t2.ret], ctx);
-  } else if (isTCon(t1) && isTCon(t2) && t1.name === t2.name) {
+  if (isTVar(t1)) return bind(t1, t2);
+  if (isTVar(t2)) return bind(t2, t1);
+  if (isTFun(t1) && isTFun(t2)) return unifyFuncs(t1, t2, ctx);
+  if (isTCon(t1) && isTCon(t2) && t1.name === t2.name) {
     return unifyMany(t1.params, t2.params, ctx);
-  } else if (isTUnion(t1) && isTUnion(t2)) {
-    // Assume that the union types have been normalized by this point
-    // This only works if the types that make up the unions are ordered
-    // consistently.  Is there a way to do this?
-    return unifyMany(t1.types, t2.types, ctx);
-  } else if (
-    isTTuple(t1) &&
-    isTTuple(t2) &&
-    t1.types.length === t2.types.length
-  ) {
-    // TODO: create a custom fork unifyMany() that can report which elements
-    // failed to unify within t1 and t2
-    return unifyMany(t1.types, t2.types, ctx);
-  } else if (isTRec(t1) && isTRec(t2)) {
-    const keys1 = t1.properties.map((prop) => prop.name);
-    const keys2 = t2.properties.map((prop) => prop.name);
+  }
+  if (isTUnion(t1) && isTUnion(t2)) return unifyUnions(t1, t2, ctx);
+  if (isTTuple(t1) && isTTuple(t2)) return unifyTuples(t1, t2, ctx);
+  if (isTRec(t1) && isTRec(t2)) return unifyRecords(t1, t2, ctx);
 
-    let missingKeys: Set<string>;
-
-    missingKeys = Set(keys1).subtract(keys2);
-    if (missingKeys.size > 0) {
-      if (t2.frozen) {
-        throw new Error(
-          `${print(t1)} has the following extra keys: ${missingKeys.join(", ")}`
-        );
-      } else {
-        throw new Error(
-          `${print(t2)} is missing the following keys: ${missingKeys.join(
-            ", "
-          )}`
-        );
-      }
-    }
-
-    missingKeys = Set(keys2).subtract(keys1);
-    if (missingKeys.size > 0) {
-      if (t1.frozen) {
-        throw new Error(
-          `${print(t2)} has following extra keys: ${missingKeys.join(", ")}`
-        );
-      } else {
-        throw new Error(
-          `${print(t1)} is missing the following keys: ${missingKeys.join(
-            ", "
-          )}`
-        );
-      }
-    }
-
-    // TODO: warn about:
-    // - keys that appear more than once in either t1 or t2
-    //   (this should probably be a parse error)
-    const keys = Set.intersect([keys1, keys2]).toJS() as string[];
-
-    const t1_obj = Object.fromEntries(
-      t1.properties.map((prop) => [prop.name, prop.type])
-    );
-    const t2_obj = Object.fromEntries(
-      t2.properties.map((prop) => [prop.name, prop.type])
-    );
-
-    const ot1 = keys.map((key) => t1_obj[key]);
-    const ot2 = keys.map((key) => t2_obj[key]);
-
-    // TODO: create a custom fork unifyMany() that knows how to report
-    // errors from individual properties failing to unify.
-    return unifyMany(ot1, ot2, ctx);
-  } else {
-    // As long as the types haven't been frozen then this is okay
-    // NOTE: We may need to add .src info in the future if we notice
-    // any places where expected type widening is occurring.
-    if ("id" in t1 && "id" in t2 && !t1.frozen && !t2.frozen) {
-      ctx.state.count++;
-      const names: string[] = [];
-      // Flattens types
-      const types = [
-        ...(isTUnion(t1) ? t1.types : [t1]),
-        ...(isTUnion(t2) ? t2.types : [t2]),
-      ].filter((type) => {
-        // Removes duplicate TCons
-        // TODO: handle TCons with params
-        if (isTCon(type) && type.params.length === 0) {
-          if (names.includes(type.name)) {
-            return false;
-          }
-          names.push(type.name);
+  // As long as the types haven't been frozen then this is okay
+  // NOTE: We may need to add .src info in the future if we notice
+  // any places where expected type widening is occurring.
+  if ("id" in t1 && "id" in t2 && !t1.frozen && !t2.frozen) {
+    ctx.state.count++;
+    const names: string[] = [];
+    // Flattens types
+    const types = [
+      ...(isTUnion(t1) ? t1.types : [t1]),
+      ...(isTUnion(t2) ? t2.types : [t2]),
+    ].filter((type) => {
+      // Removes duplicate TCons
+      // TODO: handle TCons with params
+      if (isTCon(type) && type.params.length === 0) {
+        if (names.includes(type.name)) {
+          return false;
         }
-        return true;
-      });
-      const union: TUnion = {
-        tag: "TUnion",
-        id: ctx.state.count,
-        types,
+        names.push(type.name);
+      }
+      return true;
+    });
+    const union: TUnion = {
+      tag: "TUnion",
+      id: ctx.state.count,
+      types,
+    };
+    const result: Subst = Map([
+      [t1.id, union],
+      [t2.id, union],
+    ]);
+    return result;
+  }
+
+  throw new UnificationFail(t1, t2);
+};
+
+const unifyFuncs = (t1: TFun, t2: TFun, ctx: Context): Subst => {
+  // infer() only ever creates a Lam node on the left side of a constraint
+  // and an App on the right side of a constraint so this check is sufficient.
+  if (t1.src === "Lam" && t2.src === "App") {
+    // partial application
+    if (t1.args.length > t2.args.length) {
+      ctx.state.count++;
+      const t1_partial: Type = {
+        tag: "TFun",
+        id: t1.id, // is it safe to reuse `id` here?
+        args: t1.args.slice(0, t2.args.length),
+        ret: {
+          tag: "TFun",
+          id: ctx.state.count,
+          args: t1.args.slice(t2.args.length),
+          ret: t1.ret,
+        },
+        src: t1.src,
       };
-      const result: Subst = Map([
-        [t1.id, union],
-        [t2.id, union],
-      ]);
-      return result;
+      return unifyMany(
+        [...t1_partial.args, t1_partial.ret],
+        [...t2.args, t2.ret],
+        ctx
+      );
     }
 
+    // subtyping: we ignore extra args
+    // TODO: Create a `isSubType` helper function
+    // TODO: update this once we support rest params
+    if (t1.args.length < t2.args.length) {
+      const t2_without_extra_args: Type = {
+        tag: "TFun",
+        id: t2.id, // is it safe to reuse `id` here?
+        args: t2.args.slice(0, t1.args.length),
+        ret: t2.ret,
+        src: t2.src,
+      };
+      return unifyMany(
+        [...t1.args, t1.ret],
+        [...t2_without_extra_args.args, t2_without_extra_args.ret],
+        ctx
+      );
+    }
+  }
+
+  // The reverse can happen when a callback is passed as an arg
+  if (t1.src === "App" && t2.src === "Lam") {
+    // Can partial application happen in this situation?
+
+    // subtyping: we ignore extra args
+    // TODO: Create a `isSubType` helper function
+    // TODO: update this once we support rest params
+    if (t1.args.length > t2.args.length) {
+      const t1_without_extra_args: Type = {
+        tag: "TFun",
+        id: t1.id, // is it safe to reuse `id` here?
+        args: t1.args.slice(0, t2.args.length),
+        ret: t1.ret,
+        src: t1.src,
+      };
+      return unifyMany(
+        [...t1_without_extra_args.args, t1_without_extra_args.ret],
+        [...t2.args, t2.ret],
+        ctx
+      );
+    }
+  }
+
+  // TODO: add support for optional params
+  // we can model optional params as union types, e.g. int | void
+  return unifyMany([...t1.args, t1.ret], [...t2.args, t2.ret], ctx);
+};
+
+const unifyRecords = (t1: TRec, t2: TRec, ctx: Context): Subst => {
+  const keys1 = t1.properties.map((prop) => prop.name);
+  const keys2 = t2.properties.map((prop) => prop.name);
+
+  let missingKeys: Set<string>;
+
+  missingKeys = Set(keys1).subtract(keys2);
+  if (missingKeys.size > 0) {
+    if (t2.frozen) {
+      throw new ExtraProperties(t1, [...missingKeys]);
+    } else {
+      throw new MissingProperties(t2, [...missingKeys]);
+    }
+  }
+
+  missingKeys = Set(keys2).subtract(keys1);
+  if (missingKeys.size > 0) {
+    if (t1.frozen) {
+      throw new ExtraProperties(t2, [...missingKeys]);
+    } else {
+      throw new MissingProperties(t1, [...missingKeys]);
+    }
+  }
+
+  // TODO: warn about:
+  // - keys that appear more than once in either t1 or t2
+  //   (this should probably be a parse error)
+  const keys = Set.intersect([keys1, keys2]).toJS() as string[];
+
+  const t1_obj = Object.fromEntries(
+    t1.properties.map((prop) => [prop.name, prop.type])
+  );
+  const t2_obj = Object.fromEntries(
+    t2.properties.map((prop) => [prop.name, prop.type])
+  );
+
+  const ot1 = keys.map((key) => t1_obj[key]);
+  const ot2 = keys.map((key) => t2_obj[key]);
+
+  // TODO: create a custom fork unifyMany() that knows how to report
+  // errors from individual properties failing to unify.
+  return unifyMany(ot1, ot2, ctx);
+};
+
+const unifyTuples = (t1: TTuple, t2: TTuple, ctx: Context): Subst => {
+  if (t1.types.length !== t2.types.length) {
     throw new UnificationFail(t1, t2);
   }
+  // TODO: create a custom fork unifyMany() that can report which elements
+  // failed to unify within t1 and t2
+  return unifyMany(t1.types, t2.types, ctx);
 };
+
+const unifyUnions = (t1: TUnion, t2: TUnion, ctx: Context): Subst => {
+  // Assume that the union types have been normalized by this point
+  // This only works if the types that make up the unions are ordered
+  // consistently.  Is there a way to do this?
+  return unifyMany(t1.types, t2.types, ctx);
+}
 
 const composeSubs = (s1: Subst, s2: Subst): Subst => {
   return s2.map((t) => apply(s1, t)).merge(s1);

--- a/write-you-a-haskell/src/errors.ts
+++ b/write-you-a-haskell/src/errors.ts
@@ -40,3 +40,20 @@ export class UnificationMismatch extends Error {
     this.name = "UnificationMismatch";
   }
 }
+
+export class ExtraProperties extends Error {
+  constructor(type: Type, extraKeys: string[]) {
+    const message = `${print(type)} has following extra keys: ${extraKeys.join(", ")}`
+    super(message);
+    this.name = "ExtraProperties";
+  }
+}
+
+export class MissingProperties extends Error {
+  constructor(type: Type, extraKeys: string[]) {
+    const message = `${print(type)} is missing the following keys: ${extraKeys.join(", ")}`
+    super(message);
+    this.name = "MissingProperties";
+  }
+}
+

--- a/write-you-a-haskell/src/type-types.ts
+++ b/write-you-a-haskell/src/type-types.ts
@@ -1,6 +1,4 @@
-import { Map, Set } from "immutable";
-
-import { zip } from "./util";
+import { Map } from "immutable";
 
 function assertUnreachable(x: never): never {
   throw new Error("Didn't expect to get here");
@@ -70,58 +68,6 @@ export function print(t: Type | Scheme): string {
     default:
       assertUnreachable(t);
   }
-}
-
-export function equal(a: Type | Scheme, b: Type | Scheme): boolean {
-  if (a.tag === "TVar" && b.tag === "TVar") {
-    return a.id === b.id; // TODO: use IDs
-  } else if (a.tag === "TCon" && b.tag === "TCon") {
-    return (
-      a.name === b.name &&
-      a.params.length === b.params.length &&
-      zip(a.params, b.params).every((pair) => equal(...pair))
-    );
-  } else if (a.tag === "TFun" && b.tag === "TFun") {
-    return (
-      a.args.length === b.args.length &&
-      zip([...a.args, a.ret], [...b.args, b.ret]).every((pair) =>
-        equal(...pair)
-      )
-    );
-  } else if (a.tag === "TTuple" && b.tag === "TTuple") {
-    return (
-      a.types.length === b.types.length &&
-      zip(a.types, b.types).every((pair) => equal(...pair))
-    );
-  } else if (a.tag === "TRec" && b.tag === "TRec") {
-    if (a.properties.length === b.properties.length) {
-      const aKeys = a.properties.map(prop => prop.name);
-      const bKeys = a.properties.map(prop => prop.name);
-
-      // TODO: warn about
-      // - keys in t1 that aren't in t2
-      // - keys in t2 that aren't in t1
-      // - keys that appear more than once in either t1 or t2
-      const keys = Set.intersect([aKeys, bKeys]).toJS() as string[];
-      
-      const a_obj = Object.fromEntries(
-        a.properties.map(prop => [prop.name, prop.type])
-      );
-      const b_obj = Object.fromEntries(
-        b.properties.map(prop => [prop.name, prop.type])
-      );
-  
-      const ot1 = keys.map(key => a_obj[key]);
-      const ot2 = keys.map(key => b_obj[key]);
-
-      return zip(ot1, ot2).every((pair) => equal(...pair));
-    }
-  } else if (a.tag === "Forall" && b.tag === "Forall") {
-    throw new Error("TODO: implement equal for Schemes");
-  } else if (a.tag === b.tag) {
-    throw new Error(`TODO: implement equal for ${a.tag}`);
-  }
-  return false;
 }
 
 // NOTE: this function mutates its param


### PR DESCRIPTION
- removes the need for `equal()` to compare types
- splits up `unifies()` in type specific unify checking functions
- adds two new error classes