### PR TITLE
Add TPrim type

### DIFF
--- a/write-you-a-haskell/src/__tests__/async-await.test.ts
+++ b/write-you-a-haskell/src/__tests__/async-await.test.ts
@@ -13,14 +13,14 @@ describe("Async/Await", () => {
     const env: Env = Map();
     const result = inferExpr(env, expr);
 
-    expect(print(result)).toEqual("() => Promise<Num>");
+    expect(print(result)).toEqual("() => Promise<number>");
   });
 
   test("return value is not rewrapped if already a promise", () => {
     const ctx = tb.createCtx();
     const retVal = scheme(
       [],
-      tb.tcon("Promise", [tb.tcon("Num", [], ctx)], ctx),
+      tb.tcon("Promise", [tb.tprim("number", ctx)], ctx),
     );
     const expr: Expr = sb.lam([], sb._var("retVal"), true);
 
@@ -28,16 +28,16 @@ describe("Async/Await", () => {
     env = env.set("retVal", retVal);
     const result = inferExpr(env, expr, { count: 2 });
 
-    expect(print(result)).toEqual("() => Promise<Num>");
+    expect(print(result)).toEqual("() => Promise<number>");
   });
 
   test("awaiting a promise will unwrap it", () => {
     const ctx = tb.createCtx();
     const retVal = scheme(
       [],
-      tb.tcon("Promise", [tb.tcon("Num", [], ctx)], ctx),
+      tb.tcon("Promise", [tb.tprim("number", ctx)], ctx),
     );
-    // Passing an awaited Promise<Num> to add() verifies that we're
+    // Passing an awaited Promise<number> to add() verifies that we're
     // unwrapping promises.
     const expr: Expr = sb.lam([], sb.add(sb._await(sb._var("retVal")), sb.num(5)), true);
 
@@ -45,18 +45,18 @@ describe("Async/Await", () => {
     env = env.set("retVal", retVal);
     const result = inferExpr(env, expr, { count: 2 });
 
-    expect(print(result)).toEqual("() => Promise<Num>");
+    expect(print(result)).toEqual("() => Promise<number>");
   });
 
   test("awaiting a non-promise value is a no-op", () => {
-    // Passing an awaited Promise<Num> to add() verifies that we're
+    // Passing an awaited Promise<number> to add() verifies that we're
     // unwrapping promises.
     const expr: Expr = sb.lam([], sb.add(sb._await(sb.num(5)), sb.num(10)), true);
 
     const env: Env = Map();
     const result = inferExpr(env, expr);
 
-    expect(print(result)).toEqual("() => Promise<Num>");
+    expect(print(result)).toEqual("() => Promise<number>");
   });
 
   test("inferring an async function that returns a polymorphic promise", () => {
@@ -108,6 +108,6 @@ describe("Async/Await", () => {
     const env: Env = Map();
     const result = inferExpr(env, expr);
 
-    expect(print(result)).toEqual("() => Promise<Num>");
+    expect(print(result)).toEqual("() => Promise<number>");
   });
 });

--- a/write-you-a-haskell/src/__tests__/destructuring.test.ts
+++ b/write-you-a-haskell/src/__tests__/destructuring.test.ts
@@ -17,7 +17,7 @@ describe("destructuring", () => {
     const env: Env = Map();
     const result = inferExpr(env, expr);
 
-    expect(print(result)).toEqual("Num");
+    expect(print(result)).toEqual("number");
   });
 
   test("single property from a variable - let {x} = {x: 5, y: true} in x", () => {
@@ -38,7 +38,7 @@ describe("destructuring", () => {
 
     const result = inferExpr(env, expr);
 
-    expect(print(result)).toEqual("Num");
+    expect(print(result)).toEqual("number");
   });
 
   test("multiple properties - let {x, y} = {x: 5, y: 10} in x + y", () => {
@@ -52,7 +52,7 @@ describe("destructuring", () => {
     const env: Env = Map();
     const result = inferExpr(env, expr);
 
-    expect(print(result)).toEqual("Num");
+    expect(print(result)).toEqual("number");
   });
 
   test("renaming a property - let {x: a} = {x: 5, y: 10} in a", () => {
@@ -66,7 +66,7 @@ describe("destructuring", () => {
     const env: Env = Map();
     const result = inferExpr(env, expr);
 
-    expect(print(result)).toEqual("Num");
+    expect(print(result)).toEqual("number");
   });
 
   test("record with wildcard - let {x: a, y: _} = {x: 5, y: 10} in a", () => {
@@ -83,7 +83,7 @@ describe("destructuring", () => {
     const env: Env = Map();
     const result = inferExpr(env, expr);
 
-    expect(print(result)).toEqual("Num");
+    expect(print(result)).toEqual("number");
   });
 
   test("nested record - let {p:{x: a}} = {p:{x: 5, y: 10}} in a", () => {
@@ -102,7 +102,7 @@ describe("destructuring", () => {
     const env: Env = Map();
     const result = inferExpr(env, expr);
 
-    expect(print(result)).toEqual("Num");
+    expect(print(result)).toEqual("number");
   });
 
   test("matching literal - let {x, y: 10} = {x: 5, y: 10} in x + y", () => {
@@ -116,7 +116,7 @@ describe("destructuring", () => {
     const env: Env = Map();
     const result = inferExpr(env, expr);
 
-    expect(print(result)).toEqual("Num");
+    expect(print(result)).toEqual("number");
   });
 
   test("mismatched literal - let {x, y: true} = {x: 5, y: 10} in x", () => {
@@ -129,7 +129,7 @@ describe("destructuring", () => {
 
     const env: Env = Map();
     expect(() => inferExpr(env, expr)).toThrowErrorMatchingInlineSnapshot(
-      `"Couldn't unify Bool with Num"`
+      `"Couldn't unify boolean with number"`
     );
   });
 
@@ -143,7 +143,7 @@ describe("destructuring", () => {
 
     const env: Env = Map();
     expect(() => inferExpr(env, expr)).toThrowErrorMatchingInlineSnapshot(
-      `"{x: Num, y: Num} doesn't contain z property"`
+      `"{x: number, y: number} doesn't contain z property"`
     );
   });
 
@@ -162,7 +162,7 @@ describe("destructuring", () => {
 
     const result = inferExpr(env, expr);
 
-    expect(print(result)).toEqual("Num");
+    expect(print(result)).toEqual("number");
   });
 
   test("tuple (wrong length) - let [x] = [5, true] in x", () => {

--- a/write-you-a-haskell/src/__tests__/function.test.ts
+++ b/write-you-a-haskell/src/__tests__/function.test.ts
@@ -47,7 +47,7 @@ describe("Functions", () => {
     const env: Env = Map();
     const result = inferExpr(env, fib[1]);
 
-    expect(print(result)).toEqual("(Num) => Num");
+    expect(print(result)).toEqual("(number) => number");
   });
 
   test("let const = (x) => (y) => x", () => {
@@ -101,14 +101,14 @@ describe("Functions", () => {
       throw new Error("foo is undefined");
     }
 
-    expect(print(fooType)).toEqual("(Num) => Num");
+    expect(print(fooType)).toEqual("(number) => number");
 
     const yType = env.get("y");
     if (!yType) {
       throw new Error("y is undefined");
     }
 
-    expect(print(yType)).toEqual("(Bool) => Bool");
+    expect(print(yType)).toEqual("(boolean) => boolean");
   });
 
   test("let compose = (f) => (g) => (x) => g(f(x))", () => {
@@ -203,7 +203,7 @@ describe("Functions", () => {
     let env: Env = Map();
     const result = inferExpr(env, until[1]);
 
-    expect(print(result)).toEqual("<a>((a) => Bool, (a) => a, a) => a");
+    expect(print(result)).toEqual("<a>((a) => boolean, (a) => a, a) => a");
   });
 
   test("no args", () => {
@@ -212,7 +212,7 @@ describe("Functions", () => {
     let env: Env = Map();
     const result = inferExpr(env, foo[1]);
 
-    expect(print(result)).toEqual("() => Num");
+    expect(print(result)).toEqual("() => number");
   });
 });
 
@@ -234,7 +234,7 @@ describe("partial applicaiton", () => {
       throw new Error("add5 is undefined");
     }
 
-    expect(print(result)).toEqual("(Num) => Num");
+    expect(print(result)).toEqual("(number) => number");
   });
 
   test("let sum = add(5)(10)", () => {
@@ -257,7 +257,7 @@ describe("partial applicaiton", () => {
       throw new Error("sum is undefined");
     }
 
-    expect(print(result)).toEqual("Num");
+    expect(print(result)).toEqual("number");
   });
 
   test("((a, b) => a + b)(5)", () => {
@@ -271,7 +271,7 @@ describe("partial applicaiton", () => {
     const env: Env = Map();
     const result = inferExpr(env, add5[1]);
 
-    expect(print(result)).toEqual("(Num) => Num");
+    expect(print(result)).toEqual("(number) => number");
   });
 });
 
@@ -303,7 +303,7 @@ describe("function subtyping", () => {
         [
           tb.tcon("Array", [aVar], ctx),
           // Why is this TFun's `src` an "App"?
-          tb.tfun([aVar, tb.tcon("Num", [], ctx)], bVar, ctx, "App"),
+          tb.tfun([aVar, tb.tprim("number", ctx)], bVar, ctx, "App"),
         ],
         tb.tcon("Array", [bVar], ctx),
         ctx
@@ -315,7 +315,7 @@ describe("function subtyping", () => {
 
     const intArray = scheme(
       [],
-      tb.tcon("Array", [tb.tcon("Num", [], ctx)], ctx)
+      tb.tcon("Array", [tb.tprim("number", ctx)], ctx)
     );
 
     env = env.set("array", intArray);
@@ -328,7 +328,7 @@ describe("function subtyping", () => {
 
     const result = inferExpr(env, call, ctx.state);
 
-    expect(print(result)).toEqual("Array<Bool>");
+    expect(print(result)).toEqual("Array<boolean>");
   });
 
   test("partial application of a callback", () => {
@@ -341,7 +341,7 @@ describe("function subtyping", () => {
       tb.tfun(
         [
           tb.tcon("Array", [aVar], ctx),
-          tb.tfun([aVar, tb.tcon("Num", [], ctx)], bVar, ctx, "App"),
+          tb.tfun([aVar, tb.tprim("number", ctx)], bVar, ctx, "App"),
         ],
         tb.tcon("Array", [bVar], ctx),
         ctx
@@ -353,7 +353,7 @@ describe("function subtyping", () => {
 
     const intArray = scheme(
       [],
-      tb.tcon("Array", [tb.tcon("Num", [], ctx)], ctx)
+      tb.tcon("Array", [tb.tprim("number", ctx)], ctx)
     );
 
     env = env.set("array", intArray);
@@ -375,6 +375,6 @@ describe("function subtyping", () => {
 
     const result = inferExpr(env, call, ctx.state);
 
-    expect(print(result)).toEqual("Array<(Num) => Num>");
+    expect(print(result)).toEqual("Array<(number) => number>");
   });
 });

--- a/write-you-a-haskell/src/__tests__/infer.test.ts
+++ b/write-you-a-haskell/src/__tests__/infer.test.ts
@@ -94,7 +94,7 @@ describe("inferExpr", () => {
       const env: Env = Map();
       const result = inferExpr(env, nsucc[1]);
 
-      expect(print(result)).toEqual("(Num) => Num");
+      expect(print(result)).toEqual("(number) => number");
     });
 
     test("let npred x = x - 1", () => {
@@ -106,7 +106,7 @@ describe("inferExpr", () => {
       const env: Env = Map();
       const result = inferExpr(env, nsucc[1]);
 
-      expect(print(result)).toEqual("(Num) => Num");
+      expect(print(result)).toEqual("(number) => number");
     });
   });
 
@@ -126,7 +126,7 @@ describe("inferExpr", () => {
         throw new Error("poly is undefined");
       }
 
-      expect(print(result)).toEqual("Num");
+      expect(print(result)).toEqual("number");
     });
 
     test("let self = ((x) => x)((x) => x)", () => {
@@ -171,7 +171,7 @@ describe("inferExpr", () => {
       const env: Env = Map();
       const result = inferExpr(env, f[1]);
 
-      expect(print(result)).toEqual("(Num, Num) => Num");
+      expect(print(result)).toEqual("(number, number) => number");
     });
   });
 
@@ -193,14 +193,14 @@ describe("inferExpr", () => {
         sb.app(sb._var("promisify"), [sb.num(5)]),
       ];
       const intResult = inferExpr(env, intCall[1], ctx.state);
-      expect(print(intResult)).toEqual("Promise<Num>");
+      expect(print(intResult)).toEqual("Promise<number>");
 
       const boolCall: Binding = [
         "call",
         sb.app(sb._var("promisify"), [sb.bool(true)]),
       ];
       const boolResult = inferExpr(env, boolCall[1], ctx.state);
-      expect(print(boolResult)).toEqual("Promise<Bool>");
+      expect(print(boolResult)).toEqual("Promise<boolean>");
     });
 
     test("extract value from type constructor", () => {
@@ -225,7 +225,7 @@ describe("inferExpr", () => {
       );
 
       const result = inferExpr(env, addFoos, { count: 3 });
-      expect(print(result)).toEqual("(Foo<Num>, Foo<Num>) => Num");
+      expect(print(result)).toEqual("(Foo<number>, Foo<number>) => number");
     });
 
     test("extract value from type constructor 2", () => {
@@ -240,7 +240,7 @@ describe("inferExpr", () => {
       let env: Env = Map();
 
       env = env.set("extract", extractScheme);
-      // x is of type Foo<Num>
+      // x is of type Foo<number>
       env = env.set("x", {
         tag: "Forall",
         qualifiers: [],
@@ -248,14 +248,14 @@ describe("inferExpr", () => {
           tag: "TCon",
           id: 3,
           name: "Foo",
-          params: [{ tag: "TCon", id: 4, name: "Num", params: [] }],
+          params: [{ tag: "TCon", id: 4, name: "number", params: [] }],
         },
       });
 
       const extractedX = sb.app(sb._var("extract"), [sb._var("x")]);
 
       const result = inferExpr(env, extractedX, { count: 5 });
-      expect(print(result)).toEqual("Num");
+      expect(print(result)).toEqual("number");
     });
   });
 
@@ -282,9 +282,7 @@ describe("inferExpr", () => {
       let env: Env = Map();
       env = env.set(_add[0], inferExpr(env, _add[1]));
 
-      expect(() => inferExpr(env, expr)).toThrowErrorMatchingInlineSnapshot(
-        `"Couldn't unify Num with Bool"`
-      );
+      expect(() => inferExpr(env, expr)).toThrowErrorMatchingInlineSnapshot(`"Couldn't unify number with boolean"`);
     });
 
     test("InfiniteType", () => {

--- a/write-you-a-haskell/src/__tests__/record.test.ts
+++ b/write-you-a-haskell/src/__tests__/record.test.ts
@@ -17,7 +17,7 @@ describe("record", () => {
 
     const result = inferExpr(env, expr);
 
-    expect(print(result)).toEqual("{foo: Str, bar: Num}");
+    expect(print(result)).toEqual("{foo: string, bar: number}");
   });
 
   test("can infer a function returning a lambda", () => {
@@ -30,7 +30,7 @@ describe("record", () => {
 
     const result = inferExpr(env, expr);
 
-    expect(print(result)).toEqual("() => {foo: Str, bar: Num}");
+    expect(print(result)).toEqual("() => {foo: string, bar: number}");
   });
 
   test("get foo", () => {
@@ -57,7 +57,7 @@ describe("record", () => {
     const result = inferExpr(env, expr);
 
     expect(print(getFoo)).toEqual("<a, b>({foo: a, bar: b}) => a");
-    expect(print(result)).toEqual("Num");
+    expect(print(result)).toEqual("number");
   });
 
   describe("errors", () => {
@@ -86,9 +86,7 @@ describe("record", () => {
         ]),
       ]);
 
-      expect(() => inferExpr(env, expr)).toThrowErrorMatchingInlineSnapshot(
-        `"{foo: Num, bar: Str, baz: Bool} has following extra keys: baz"`
-      );
+      expect(() => inferExpr(env, expr)).toThrowErrorMatchingInlineSnapshot(`"{foo: number, bar: string, baz: boolean} has following extra keys: baz"`);
     });
 
     test("missing property", () => {
@@ -112,9 +110,7 @@ describe("record", () => {
         sb.rec([sb.prop("foo", sb.num(5))]),
       ]);
 
-      expect(() => inferExpr(env, expr)).toThrowErrorMatchingInlineSnapshot(
-        `"{foo: Num} is missing the following keys: bar"`
-      );
+      expect(() => inferExpr(env, expr)).toThrowErrorMatchingInlineSnapshot(`"{foo: number} is missing the following keys: bar"`);
     });
 
     test("property has wrong type", () => {
@@ -125,13 +121,13 @@ describe("record", () => {
           [
             tb.trec(
               [
-                tb.tprop("foo", tb.tcon("Num", [], ctx)),
-                tb.tprop("bar", tb.tcon("Str", [], ctx)),
+                tb.tprop("foo", tb.tprim("number", ctx)),
+                tb.tprop("bar", tb.tprim("string", ctx)),
               ],
               ctx
             ),
           ],
-          tb.tcon("Bool", [], ctx),
+          tb.tprim("boolean", ctx),
           ctx
         )
       );
@@ -144,9 +140,7 @@ describe("record", () => {
         sb.rec([sb.prop("foo", sb.num(5)), sb.prop("bar", sb.bool(true))]),
       ]);
 
-      expect(() => inferExpr(env, expr)).toThrowErrorMatchingInlineSnapshot(
-        `"Couldn't unify Str with Bool"`
-      );
+      expect(() => inferExpr(env, expr)).toThrowErrorMatchingInlineSnapshot(`"Couldn't unify string with boolean"`);
     });
   });
 

--- a/write-you-a-haskell/src/__tests__/tuple.test.ts
+++ b/write-you-a-haskell/src/__tests__/tuple.test.ts
@@ -14,7 +14,7 @@ describe("tuple", () => {
 
     const result = inferExpr(env, expr);
 
-    expect(print(result)).toEqual("[Num, Bool, Str]");
+    expect(print(result)).toEqual("[number, boolean, string]");
   });
 
   test("can infer a function returning a lambda", () => {
@@ -27,7 +27,7 @@ describe("tuple", () => {
 
     const result = inferExpr(env, expr);
 
-    expect(print(result)).toEqual("() => [Num, Bool, Str]");
+    expect(print(result)).toEqual("() => [number, boolean, string]");
   });
 
   test("snd (function)", () => {
@@ -50,7 +50,7 @@ describe("tuple", () => {
     const result = inferExpr(env, expr);
 
     expect(print(snd)).toEqual("<a, b>([a, b]) => b");
-    expect(print(result)).toEqual("Str");
+    expect(print(result)).toEqual("string");
   });
 
   describe("errors", () => {
@@ -71,9 +71,7 @@ describe("tuple", () => {
         sb.tuple([sb.num(5), sb.str("hello"), sb.bool(true)]),
       ]);
 
-      expect(() => inferExpr(env, expr)).toThrowErrorMatchingInlineSnapshot(
-        `"Couldn't unify [b, c] with [Num, Str, Bool]"`
-      );
+      expect(() => inferExpr(env, expr)).toThrowErrorMatchingInlineSnapshot(`"Couldn't unify [b, c] with [number, string, boolean]"`);
     });
 
     test("arg tuple has few many elements", () => {
@@ -82,9 +80,7 @@ describe("tuple", () => {
 
       const expr: Expr = sb.app(sb._var("snd"), [sb.tuple([sb.num(5)])]);
 
-      expect(() => inferExpr(env, expr)).toThrowErrorMatchingInlineSnapshot(
-        `"Couldn't unify [b, c] with [Num]"`
-      );
+      expect(() => inferExpr(env, expr)).toThrowErrorMatchingInlineSnapshot(`"Couldn't unify [b, c] with [number]"`);
     });
 
     test("element mismatch", () => {
@@ -92,8 +88,8 @@ describe("tuple", () => {
       const foo: Scheme = scheme(
         [],
         tb.tfun(
-          [tb.ttuple([tb.tcon("Num", [], ctx), tb.tcon("Str", [], ctx)], ctx)],
-          tb.tcon("Str", [], ctx),
+          [tb.ttuple([tb.tprim("number", ctx), tb.tprim("string", ctx)], ctx)],
+          tb.tprim("string", ctx),
           ctx
         )
       );
@@ -106,9 +102,7 @@ describe("tuple", () => {
         sb.tuple([sb.num(5), sb.bool(true)]),
       ]);
 
-      expect(() => inferExpr(env, expr)).toThrowErrorMatchingInlineSnapshot(
-        `"Couldn't unify Str with Bool"`
-      );
+      expect(() => inferExpr(env, expr)).toThrowErrorMatchingInlineSnapshot(`"Couldn't unify string with boolean"`);
     });
   });
 

--- a/write-you-a-haskell/src/constraint-solver.ts
+++ b/write-you-a-haskell/src/constraint-solver.ts
@@ -10,6 +10,7 @@ import {
   Context,
   isTTuple,
   isTRec,
+  isTPrim,
   TFun,
   TRec,
   TTuple,
@@ -58,6 +59,7 @@ export const unifies = (t1: Type, t2: Type, ctx: Context): Subst => {
   if (isTVar(t1)) return bind(t1, t2);
   if (isTVar(t2)) return bind(t2, t1);
   if (isTFun(t1) && isTFun(t2)) return unifyFuncs(t1, t2, ctx);
+  if (isTPrim(t1) && isTPrim(t2) && t1.name === t2.name) return emptySubst;
   if (isTCon(t1) && isTCon(t2) && t1.name === t2.name) {
     return unifyMany(t1.params, t2.params, ctx);
   }

--- a/write-you-a-haskell/src/syntax-types.ts
+++ b/write-you-a-haskell/src/syntax-types.ts
@@ -1,14 +1,16 @@
+import { PrimName } from "./type-types";
+
+// TODO: provide a way to declare types as part of the syntax AST
+// We'll need this eventually to support defining bindings to external libraries.
+// It will also help simplify writing tests where we need to define the type of
+// of something that we can't easily infer from an expression.
+
 // TODO: update tags to match type name
 export type EApp = { tag: "App"; fn: Expr; args: readonly Expr[] };
 export type EAwait = { tag: "Await"; expr: Expr };
 export type EFix = { tag: "Fix"; expr: Expr };
 export type EIf = { tag: "If"; cond: Expr; th: Expr; el: Expr };
-export type ELam = {
-  tag: "Lam";
-  args: readonly string[];
-  body: Expr;
-  async?: boolean;
-};
+export type ELam = { tag: "Lam"; args: readonly string[]; body: Expr; async?: boolean }; // prettier-ignore
 export type ELet = { tag: "Let"; pattern: Pattern; value: Expr; body: Expr };
 export type ELit = { tag: "Lit"; value: Literal };
 export type EOp = { tag: "Op"; op: Binop; left: Expr; right: Expr };
@@ -42,12 +44,15 @@ export type Program = { tag: "Program"; decls: readonly Decl[]; expr: Expr };
 
 export type Decl = [string, Expr];
 
-export type Pattern =
-  | { tag: "PVar"; name: string } // treat this the same was a `name: string` in Let
-  | { tag: "PWild" } // corresponds to `_`
-  | { tag: "PRec"; properties: readonly PProp[] }
-  | { tag: "PTuple"; patterns: readonly Pattern[] }
-  | { tag: "PLit"; value: ELit };
+export type PVar = { tag: "PVar"; name: string }; // treat this the same was a `name: string` in Let
+export type PWild = { tag: "PWild" }; // corresponds to `_`
+export type PRec = { tag: "PRec"; properties: readonly PProp[] };
+export type PTuple = { tag: "PTuple"; patterns: readonly Pattern[] };
+export type PLit = { tag: "PLit"; value: ELit };
+export type PPrim = { tag: "PPrim"; name?: string; primName: PrimName };
+
+export type Pattern = PVar | PWild | PRec | PTuple | PLit | PPrim;
+
 // TODO:
 // - PCon, need to wait until the introduction of opaque types and/or type aliases
 //   since it doesn't make sense for Array<Num> to be modeled as a type constructor

--- a/write-you-a-haskell/src/type-builders.ts
+++ b/write-you-a-haskell/src/type-builders.ts
@@ -2,15 +2,21 @@ import { Map } from "immutable";
 
 import * as t from "./type-types";
 
+const newId = (ctx: t.Context): number => ++ctx.state.count;
+
 export const tvar = (name: string, ctx: t.Context): t.TVar => ({
   tag: "TVar",
-  id: ++ctx.state.count,
+  id: newId(ctx),
   name,
 });
 
-export const tcon = (name: string, params: readonly t.Type[], ctx: t.Context): t.TCon => ({
+export const tcon = (
+  name: string,
+  params: readonly t.Type[],
+  ctx: t.Context
+): t.TCon => ({
   tag: "TCon",
-  id: ++ctx.state.count,
+  id: newId(ctx),
   name,
   params,
 });
@@ -22,7 +28,7 @@ export const tfun = (
   src?: "App" | "Fix" | "Lam"
 ): t.TFun => ({
   tag: "TFun",
-  id: ++ctx.state.count,
+  id: newId(ctx),
   args,
   ret,
   src,
@@ -30,19 +36,22 @@ export const tfun = (
 
 export const tunion = (types: readonly t.Type[], ctx: t.Context): t.TUnion => ({
   tag: "TUnion",
-  id: ++ctx.state.count,
+  id: newId(ctx),
   types,
 });
 
 export const ttuple = (types: readonly t.Type[], ctx: t.Context): t.TTuple => ({
   tag: "TTuple",
-  id: ++ctx.state.count,
+  id: newId(ctx),
   types,
 });
 
-export const trec = (properties: readonly t.TProp[], ctx: t.Context): t.TRec => ({
+export const trec = (
+  properties: readonly t.TProp[],
+  ctx: t.Context
+): t.TRec => ({
   tag: "TRec",
-  id: ++ctx.state.count,
+  id: newId(ctx),
   properties,
 });
 
@@ -59,3 +68,13 @@ export const createCtx = (): t.Context => {
   };
   return ctx;
 };
+
+export const tprim = (name: t.PrimName, ctx: t.Context): t.TPrim => ({
+  tag: "TPrim",
+  id: newId(ctx),
+  name,
+});
+
+export const tNum = (ctx: t.Context): t.TPrim => tprim("number", ctx);
+export const tStr = (ctx: t.Context): t.TPrim => tprim("string", ctx);
+export const tBool = (ctx: t.Context): t.TPrim => tprim("boolean", ctx);

--- a/write-you-a-haskell/src/type-types.ts
+++ b/write-you-a-haskell/src/type-types.ts
@@ -24,6 +24,18 @@ export type TUnion = TCommon & { tag: "TUnion"; types: readonly Type[] };
 export type TRec = TCommon & { tag: "TRec"; properties: readonly TProp[] };
 export type TTuple = TCommon & { tag: "TTuple"; types: readonly Type[] };
 export type TLit = TCommon & { tag: "TLit"; value: Literal };
+// TODO: add TPrim to model the following primitive types:
+// - string, boolean, number, null, undefined, symbol, bigint
+// Each TLit must belong to at least one TPrimitive type
+// e.g. TLit(3) belongs to TPrim(number) (and also TPrim(bigint))
+// It would be nice if we could model the difference between ints and floats.
+// Right now TPrim(number) contains both ints and floats.  The following
+// two hierarchies are more accurate.
+// - TLit(3) < ?(int) < ?(float) < TPrim(number)
+// - TLit(3) < ?(int) < TPrim(bigint)
+// Tracking what numbers are integers are important for the type safety
+// or certain APIs that require the use of integers (or even natural numbers)
+// such as indexing into an array.
 
 // TODO: add `optional: boolean` - equivalent to `T | undefined`
 export type TProp = { tag: "TProp"; name: string; type: Type };

--- a/write-you-a-haskell/src/util.ts
+++ b/write-you-a-haskell/src/util.ts
@@ -8,6 +8,7 @@ import {
   isTUnion,
   isTRec,
   isTTuple,
+  isTPrim,
   isScheme,
   scheme,
 } from "./type-types";
@@ -25,6 +26,9 @@ export function apply(s: Subst, env: Env): Env;
 export function apply(s: Subst, a: any): any {
   // instance Substitutable Type
   if (isTVar(a)) {
+    return s.get(a.id) ?? a;
+  }
+  if (isTPrim(a)) {
     return s.get(a.id) ?? a;
   }
   if (isTCon(a)) {
@@ -113,6 +117,9 @@ export function ftv(a: any): any {
   }
   if (isTVar(a)) {
     return Set([a]); // Set.singleton a
+  }
+  if (isTPrim(a)) {
+    return Set([]);
   }
   if (isTFun(a)) {
     return Set.union([...a.args.map(ftv), ftv(a.ret)]); // ftv t1 `Set.union` ftv t2


### PR DESCRIPTION
This is used to model primitives `number`, `boolean`, and `string`.