### PR TITLE
[wyah]: rudimentary support for type aliases and member access

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "typescript.tsdk": "node_modules/typescript/lib"
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -98,5 +98,5 @@
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*", "write-you-a-haskell/**/*"]
 }

--- a/write-you-a-haskell/src/__tests__/array.test.ts
+++ b/write-you-a-haskell/src/__tests__/array.test.ts
@@ -2,7 +2,7 @@ import { Map } from "immutable";
 
 import { inferExpr } from "../infer";
 import { Expr } from "../syntax-types";
-import { Env, print, scheme } from "../type-types";
+import { Env, freeze, print, scheme } from "../type-types";
 import * as sb from "../syntax-builders";
 import * as tb from "../type-builders";
 
@@ -77,5 +77,94 @@ describe("Array", () => {
     const result3 = inferExpr(env, appExpr);
 
     expect(print(result3)).toMatchInlineSnapshot(`"Array<5>"`);
+
+    const appExpr2: Expr = sb.app(sb.mem("strArray", "map"), [
+      sb.lam(["elem", "index", "array"], sb._var("index")),
+    ]);
+    const result4 = inferExpr(env, appExpr2);
+
+    expect(print(result4)).toMatchInlineSnapshot(`"Array<number>"`);
+
+    const appExpr3: Expr = sb.app(sb.mem("strArray", "map"), [
+      sb.lam(["elem", "index", "array"], sb._var("array")),
+    ]);
+    const result5 = inferExpr(env, appExpr3);
+
+    expect(print(result5)).toMatchInlineSnapshot(`"Array<Array<string>>"`);
+
+    // TODO: turn this into a separate test case so that we can investigate
+    // separately.
+    const appExpr4: Expr = sb.app(sb.mem("strArray", "map"), [
+      sb.lam(["elem", "index", "array"], sb.mem("array", "length")),
+    ]);
+    const result6 = inferExpr(env, appExpr4);
+
+    expect(print(result6)).toMatchInlineSnapshot(`"<a>a"`);
+  });
+
+  test("member access on TVar that doesn't exist in env", () => {
+    const ctx = tb.createCtx();
+    const tVar = tb.tvar("T", ctx);
+    const uVar = tb.tvar("U", ctx);
+    const sc = scheme(
+      [tVar],
+      tb.trec(
+        [
+          tb.tprop("length", tb.tprim("number", ctx)),
+          tb.tprop(
+            "map",
+            // TODO: properties need to be able to accept Schemes
+            // as well as types.
+            tb.tfun(
+              [
+                tb.tfun(
+                  [
+                    tVar,
+                    tb.tprim("number", ctx),
+                    // TODO: how do we handle record types that
+                    // reference themselves.
+                    tb.tcon("Array", [tVar], ctx),
+                  ],
+                  uVar,
+                  ctx
+                ),
+              ],
+              tb.tcon("Array", [uVar], ctx),
+              ctx
+            )
+          ),
+        ],
+        ctx
+      )
+    );
+    freeze(sc.type);
+
+    let env: Env = Map();
+    env = env.set("Array", sc);
+
+    expect(print(sc)).toMatchInlineSnapshot(
+      `"<T>{length: number, map: ((T, number, Array<T>) => U) => Array<U>}"`
+    );
+
+    env = env.set(
+      "strArray",
+      scheme([], tb.tcon("Array", [tb.tprim("string", ctx)], ctx))
+    );
+
+    const expr: Expr = sb._var("strArray");
+    const result1 = inferExpr(env, expr, ctx.state);
+
+    expect(print(result1)).toMatchInlineSnapshot(`"Array<string>"`);
+
+    const appExpr4: Expr = sb.app(sb.mem("strArray", "map"), [
+      sb.lam(["elem", "index", "array"], sb.mem("array", "length")),
+    ]);
+    const result6 = inferExpr(env, appExpr4, ctx.state);
+
+    // We're getting closer, this is still incorrect.  It should be
+    // Array<number>.
+    // We're either missing (or dropping) a constraint between
+    // array and {length: number} at some point.
+    expect(print(result6)).toMatchInlineSnapshot(`"Array<number>"`);
   });
 });

--- a/write-you-a-haskell/src/__tests__/array.test.ts
+++ b/write-you-a-haskell/src/__tests__/array.test.ts
@@ -1,0 +1,81 @@
+import { Map } from "immutable";
+
+import { inferExpr } from "../infer";
+import { Expr } from "../syntax-types";
+import { Env, print, scheme } from "../type-types";
+import * as sb from "../syntax-builders";
+import * as tb from "../type-builders";
+
+describe("Array", () => {
+  test("parametric definition of object w/ methods", () => {
+    const ctx = tb.createCtx();
+    const tVar = tb.tvar("T", ctx);
+    const uVar = tb.tvar("U", ctx);
+    const sc = scheme(
+      [tVar],
+      tb.trec(
+        [
+          tb.tprop("length", tb.tprim("number", ctx)),
+          tb.tprop(
+            "map",
+            // TODO: properties need to be able to accept Schemes
+            // as well as types.
+            tb.tfun(
+              [
+                tb.tfun(
+                  [
+                    tVar,
+                    tb.tprim("number", ctx),
+                    // TODO: how do we handle record types that
+                    // reference themselves.
+                    tb.tcon("Array", [tVar], ctx),
+                  ],
+                  uVar,
+                  ctx
+                ),
+              ],
+              tb.tcon("Array", [uVar], ctx),
+              ctx
+            )
+          ),
+        ],
+        ctx
+      )
+    );
+
+    let env: Env = Map();
+    env = env.set("Array", sc);
+
+    expect(print(sc)).toMatchInlineSnapshot(
+      `"<T>{length: number, map: ((T, number, Array<T>) => U) => Array<U>}"`
+    );
+
+    env = env.set(
+      "strArray",
+      scheme([], tb.tcon("Array", [tb.tprim("string", ctx)], ctx))
+    );
+
+    const expr: Expr = sb._var("strArray");
+    const result1 = inferExpr(env, expr);
+
+    expect(print(result1)).toMatchInlineSnapshot(`"Array<string>"`);
+
+    const memExpr: Expr = sb.mem("strArray", "map");
+    const result2 = inferExpr(env, memExpr);
+
+    // This is wrong on two accounts:
+    // - `a` should the only qualifier in the scheme
+    // - `a` should copy its name from the original type/scheme
+    // We need a function that converts a type to a scheme.
+    expect(print(result2)).toMatchInlineSnapshot(
+      `"<a>((string, number, Array<string>) => a) => Array<a>"`
+    );
+
+    const appExpr: Expr = sb.app(sb.mem("strArray", "map"), [
+      sb.lam(["elem", "index", "array"], sb.num(5)),
+    ]);
+    const result3 = inferExpr(env, appExpr);
+
+    expect(print(result3)).toMatchInlineSnapshot(`"Array<5>"`);
+  });
+});

--- a/write-you-a-haskell/src/__tests__/array.test.ts
+++ b/write-you-a-haskell/src/__tests__/array.test.ts
@@ -2,53 +2,26 @@ import { Map } from "immutable";
 
 import { inferExpr } from "../infer";
 import { Expr } from "../syntax-types";
-import { Env, freeze, print, scheme } from "../type-types";
+import { Context, Env } from "../context";
+import { Scheme, freeze, print, scheme } from "../type-types";
 import * as sb from "../syntax-builders";
 import * as tb from "../type-builders";
 
 describe("Array", () => {
-  test("parametric definition of object w/ methods", () => {
+  test("printing the type", () => {
     const ctx = tb.createCtx();
-    const tVar = tb.tvar("T", ctx);
-    const uVar = tb.tvar("U", ctx);
-    const sc = scheme(
-      [tVar],
-      tb.trec(
-        [
-          tb.tprop("length", tb.tprim("number", ctx)),
-          tb.tprop(
-            "map",
-            // TODO: properties need to be able to accept Schemes
-            // as well as types.
-            tb.tfun(
-              [
-                tb.tfun(
-                  [
-                    tVar,
-                    tb.tprim("number", ctx),
-                    // TODO: how do we handle record types that
-                    // reference themselves.
-                    tb.tcon("Array", [tVar], ctx),
-                  ],
-                  uVar,
-                  ctx
-                ),
-              ],
-              tb.tcon("Array", [uVar], ctx),
-              ctx
-            )
-          ),
-        ],
-        ctx
-      )
-    );
-
-    let env: Env = Map();
-    env = env.set("Array", sc);
+    const sc = createArrayScheme(ctx);
 
     expect(print(sc)).toMatchInlineSnapshot(
       `"<T>{length: number, map: ((T, number, Array<T>) => U) => Array<U>}"`
     );
+  });
+
+  test("strArray = Array<string>", () => {
+    const ctx = tb.createCtx();
+
+    let env: Env = Map();
+    env = env.set("Array", createArrayScheme(ctx));
 
     env = env.set(
       "strArray",
@@ -56,115 +29,146 @@ describe("Array", () => {
     );
 
     const expr: Expr = sb._var("strArray");
-    const result1 = inferExpr(env, expr);
+    const result = inferExpr(env, expr, ctx.state);
 
-    expect(print(result1)).toMatchInlineSnapshot(`"Array<string>"`);
+    expect(print(result)).toMatchInlineSnapshot(`"Array<string>"`);
+  });
 
-    const memExpr: Expr = sb.mem("strArray", "map");
-    const result2 = inferExpr(env, memExpr);
+  test("type of strArray.map", () => {
+    const ctx = tb.createCtx();
+
+    let env: Env = Map();
+    env = env.set("Array", createArrayScheme(ctx));
+
+    env = env.set(
+      "strArray",
+      scheme([], tb.tcon("Array", [tb.tprim("string", ctx)], ctx))
+    );
+
+    const expr: Expr = sb.mem("strArray", "map");
+    const result = inferExpr(env, expr, ctx.state);
 
     // This is wrong on two accounts:
     // - `a` should the only qualifier in the scheme
     // - `a` should copy its name from the original type/scheme
     // We need a function that converts a type to a scheme.
-    expect(print(result2)).toMatchInlineSnapshot(
+    expect(print(result)).toMatchInlineSnapshot(
       `"<a>((string, number, Array<string>) => a) => Array<a>"`
     );
-
-    const appExpr: Expr = sb.app(sb.mem("strArray", "map"), [
-      sb.lam(["elem", "index", "array"], sb.num(5)),
-    ]);
-    const result3 = inferExpr(env, appExpr);
-
-    expect(print(result3)).toMatchInlineSnapshot(`"Array<5>"`);
-
-    const appExpr2: Expr = sb.app(sb.mem("strArray", "map"), [
-      sb.lam(["elem", "index", "array"], sb._var("index")),
-    ]);
-    const result4 = inferExpr(env, appExpr2);
-
-    expect(print(result4)).toMatchInlineSnapshot(`"Array<number>"`);
-
-    const appExpr3: Expr = sb.app(sb.mem("strArray", "map"), [
-      sb.lam(["elem", "index", "array"], sb._var("array")),
-    ]);
-    const result5 = inferExpr(env, appExpr3);
-
-    expect(print(result5)).toMatchInlineSnapshot(`"Array<Array<string>>"`);
-
-    // TODO: turn this into a separate test case so that we can investigate
-    // separately.
-    const appExpr4: Expr = sb.app(sb.mem("strArray", "map"), [
-      sb.lam(["elem", "index", "array"], sb.mem("array", "length")),
-    ]);
-    const result6 = inferExpr(env, appExpr4);
-
-    expect(print(result6)).toMatchInlineSnapshot(`"<a>a"`);
   });
 
-  test("member access on TVar that doesn't exist in env", () => {
+  test("strArray.map((elem, index, array) => 5) -> Array<5>", () => {
     const ctx = tb.createCtx();
-    const tVar = tb.tvar("T", ctx);
-    const uVar = tb.tvar("U", ctx);
-    const sc = scheme(
-      [tVar],
-      tb.trec(
-        [
-          tb.tprop("length", tb.tprim("number", ctx)),
-          tb.tprop(
-            "map",
-            // TODO: properties need to be able to accept Schemes
-            // as well as types.
-            tb.tfun(
-              [
-                tb.tfun(
-                  [
-                    tVar,
-                    tb.tprim("number", ctx),
-                    // TODO: how do we handle record types that
-                    // reference themselves.
-                    tb.tcon("Array", [tVar], ctx),
-                  ],
-                  uVar,
-                  ctx
-                ),
-              ],
-              tb.tcon("Array", [uVar], ctx),
-              ctx
-            )
-          ),
-        ],
-        ctx
-      )
-    );
-    freeze(sc.type);
 
     let env: Env = Map();
-    env = env.set("Array", sc);
-
-    expect(print(sc)).toMatchInlineSnapshot(
-      `"<T>{length: number, map: ((T, number, Array<T>) => U) => Array<U>}"`
-    );
+    env = env.set("Array", createArrayScheme(ctx));
 
     env = env.set(
       "strArray",
       scheme([], tb.tcon("Array", [tb.tprim("string", ctx)], ctx))
     );
 
-    const expr: Expr = sb._var("strArray");
-    const result1 = inferExpr(env, expr, ctx.state);
+    // TODO: allow `(elem) => 5` to be passed as the callback
+    const expr: Expr = sb.app(sb.mem("strArray", "map"), [
+      sb.lam(["elem", "index", "array"], sb.num(5)),
+    ]);
+    const result = inferExpr(env, expr, ctx.state);
 
-    expect(print(result1)).toMatchInlineSnapshot(`"Array<string>"`);
+    expect(print(result)).toMatchInlineSnapshot(`"Array<5>"`);
+  });
 
-    const appExpr4: Expr = sb.app(sb.mem("strArray", "map"), [
+  test("strArray.map((elem, index, array) => index) -> Array<number>", () => {
+    const ctx = tb.createCtx();
+
+    let env: Env = Map();
+    env = env.set("Array", createArrayScheme(ctx));
+
+    env = env.set(
+      "strArray",
+      scheme([], tb.tcon("Array", [tb.tprim("string", ctx)], ctx))
+    );
+
+    const expr: Expr = sb.app(sb.mem("strArray", "map"), [
+      sb.lam(["elem", "index", "array"], sb._var("index")),
+    ]);
+    const result = inferExpr(env, expr, ctx.state);
+
+    expect(print(result)).toMatchInlineSnapshot(`"Array<number>"`);
+  });
+
+  test("strArray.map((elem, index, array) => array) -> Array<Array<string>>", () => {
+    const ctx = tb.createCtx();
+
+    let env: Env = Map();
+    env = env.set("Array", createArrayScheme(ctx));
+
+    env = env.set(
+      "strArray",
+      scheme([], tb.tcon("Array", [tb.tprim("string", ctx)], ctx))
+    );
+
+    const expr: Expr = sb.app(sb.mem("strArray", "map"), [
+      sb.lam(["elem", "index", "array"], sb._var("array")),
+    ]);
+    const result = inferExpr(env, expr, ctx.state);
+
+    expect(print(result)).toMatchInlineSnapshot(`"Array<Array<string>>"`);
+  });
+
+  test("member access on TVar that doesn't exist in env", () => {
+    const ctx = tb.createCtx();
+
+    let env: Env = Map();
+    env = env.set("Array", createArrayScheme(ctx));
+
+    env = env.set(
+      "strArray",
+      scheme([], tb.tcon("Array", [tb.tprim("string", ctx)], ctx))
+    );
+  
+    const expr: Expr = sb.app(sb.mem("strArray", "map"), [
       sb.lam(["elem", "index", "array"], sb.mem("array", "length")),
     ]);
-    const result6 = inferExpr(env, appExpr4, ctx.state);
+    const result = inferExpr(env, expr, ctx.state);
 
-    // We're getting closer, this is still incorrect.  It should be
-    // Array<number>.
-    // We're either missing (or dropping) a constraint between
-    // array and {length: number} at some point.
-    expect(print(result6)).toMatchInlineSnapshot(`"Array<number>"`);
+    expect(print(result)).toMatchInlineSnapshot(`"Array<number>"`);
   });
 });
+
+const createArrayScheme = (ctx: Context): Scheme => {
+  const tVar = tb.tvar("T", ctx);
+  const uVar = tb.tvar("U", ctx);
+  const sc = scheme(
+    [tVar],
+    tb.trec(
+      [
+        tb.tprop("length", tb.tprim("number", ctx)),
+        tb.tprop(
+          "map",
+          // TODO: properties need to be able to accept Schemes
+          // as well as types.
+          tb.tfun(
+            [
+              tb.tfun(
+                [
+                  tVar,
+                  tb.tprim("number", ctx),
+                  // TODO: how do we handle record types that
+                  // reference themselves.
+                  tb.tcon("Array", [tVar], ctx),
+                ],
+                uVar,
+                ctx
+              ),
+            ],
+            tb.tcon("Array", [uVar], ctx),
+            ctx
+          )
+        ),
+      ],
+      ctx
+    )
+  );
+  freeze(sc.type);
+  return sc;
+};

--- a/write-you-a-haskell/src/__tests__/async-await.test.ts
+++ b/write-you-a-haskell/src/__tests__/async-await.test.ts
@@ -2,7 +2,8 @@ import { Map } from "immutable";
 
 import { inferExpr } from "../infer";
 import { Expr } from "../syntax-types";
-import { Env, print, scheme } from "../type-types";
+import { Env } from "../context";
+import { print, scheme } from "../type-types";
 import * as sb from "../syntax-builders";
 import * as tb from "../type-builders";
 

--- a/write-you-a-haskell/src/__tests__/destructuring.test.ts
+++ b/write-you-a-haskell/src/__tests__/destructuring.test.ts
@@ -2,7 +2,8 @@ import { Map } from "immutable";
 
 import { inferExpr } from "../infer";
 import { Expr } from "../syntax-types";
-import { Env, print } from "../type-types";
+import { Env } from "../context";
+import { print } from "../type-types";
 import * as sb from "../syntax-builders";
 
 describe("destructuring", () => {

--- a/write-you-a-haskell/src/__tests__/function.test.ts
+++ b/write-you-a-haskell/src/__tests__/function.test.ts
@@ -2,7 +2,8 @@ import { Map } from "immutable";
 
 import { inferExpr } from "../infer";
 import { Expr } from "../syntax-types";
-import { Env, print, scheme } from "../type-types";
+import { Env } from "../context";
+import { print, scheme } from "../type-types";
 import * as sb from "../syntax-builders";
 import * as tb from "../type-builders";
 

--- a/write-you-a-haskell/src/__tests__/infer.test.ts
+++ b/write-you-a-haskell/src/__tests__/infer.test.ts
@@ -2,7 +2,8 @@ import { Map } from "immutable";
 
 import { inferExpr } from "../infer";
 import { Expr } from "../syntax-types";
-import { Env, print, scheme } from "../type-types";
+import { Env } from "../context";
+import { print, scheme } from "../type-types";
 import * as sb from "../syntax-builders";
 import * as tb from "../type-builders";
 

--- a/write-you-a-haskell/src/__tests__/infer.test.ts
+++ b/write-you-a-haskell/src/__tests__/infer.test.ts
@@ -297,9 +297,7 @@ describe("inferExpr", () => {
 
       const env: Env = Map();
 
-      expect(() => inferExpr(env, omega[1])).toThrowErrorMatchingInlineSnapshot(
-        `"b appears in (b) => c"`
-      );
+      expect(() => inferExpr(env, omega[1])).toThrowErrorMatchingInlineSnapshot(`"a appears in (a) => b"`);
     });
   });
 });

--- a/write-you-a-haskell/src/__tests__/member.test.ts
+++ b/write-you-a-haskell/src/__tests__/member.test.ts
@@ -1,0 +1,9 @@
+describe("Member access", () => {
+  // TODO: test error handling
+
+  // TODO: test TMem type once it's been created
+
+  test("should pass", () => {
+    expect(true).toBe(true);
+  });
+});

--- a/write-you-a-haskell/src/__tests__/member.test.ts
+++ b/write-you-a-haskell/src/__tests__/member.test.ts
@@ -1,5 +1,137 @@
+import { Map } from "immutable";
+
+import { inferExpr } from "../infer";
+import { Expr } from "../syntax-types";
+import * as sb from "../syntax-builders";
+import * as tb from "../type-builders";
+import { Env } from "../context";
+import { scheme } from "../type-types";
+
 describe("Member access", () => {
-  // TODO: test error handling
+  describe("errors", () => {
+    test("access on literal string fails", () => {
+      const ctx = tb.createCtx();
+      let env: Env = Map();
+
+      const expr: Expr = {
+        tag: "Mem",
+        // This is just a convenience for now.
+        object: sb.str("foo"),
+        property: sb._var("bar"),
+      };
+
+      expect(() =>
+        inferExpr(env, expr, ctx.state)
+      ).toThrowErrorMatchingInlineSnapshot(
+        `"object must be a variable when accessing a member"`
+      );
+    });
+
+    test("using a property that isn't a TVar doesn't work", () => {
+      const ctx = tb.createCtx();
+      let env: Env = Map();
+      env = env.set("foo", scheme([], tb.tNum(ctx)));
+
+      const expr: Expr = {
+        tag: "Mem",
+        // This is just a convenience for now.
+        object: sb._var("foo"),
+        property: sb.str("hello"),
+      };
+
+      expect(() =>
+        inferExpr(env, expr, ctx.state)
+      ).toThrowErrorMatchingInlineSnapshot(
+        `"property must be a variable when accessing a member"`
+      );
+    });
+
+    test("attempt to access property that doesn't exist on object fails", () => {
+      const ctx = tb.createCtx();
+      let env: Env = Map();
+      env = env.set("foo", scheme([], tb.trec([], ctx)));
+
+      const expr: Expr = sb.mem("foo", "bar");
+
+      expect(() =>
+        inferExpr(env, expr, ctx.state)
+      ).toThrowErrorMatchingInlineSnapshot(`"Can't use member access on TRec"`);
+    });
+
+    test("access property on TCon that hasn't been defined fails", () => {
+      const ctx = tb.createCtx();
+      let env: Env = Map();
+      env = env.set("foo", scheme([], tb.tcon("Foo", [], ctx)));
+
+      const expr: Expr = sb.mem("foo", "bar");
+
+      expect(() =>
+        inferExpr(env, expr, ctx.state)
+      ).toThrowErrorMatchingInlineSnapshot(
+        `"No type named Foo in environment"`
+      );
+    });
+
+    test("type param count mismatch", () => {
+      const ctx = tb.createCtx();
+      const tVar = tb.tvar("T", ctx);
+      let env: Env = Map();
+      env = env.set("Foo", scheme([tVar], tb.tNum(ctx)));
+      env = env.set("foo", scheme([], tb.tcon("Foo", [], ctx)));
+
+      const expr: Expr = sb.mem("foo", "bar");
+
+      expect(() =>
+        inferExpr(env, expr, ctx.state)
+      ).toThrowErrorMatchingInlineSnapshot(
+        `"number of type params in foo doesn't match those in Foo"`
+      );
+    });
+
+    test("alias type is not a TRec", () => {
+      const ctx = tb.createCtx();
+      let env: Env = Map();
+      env = env.set("Foo", scheme([], tb.tNum(ctx)));
+      env = env.set("foo", scheme([], tb.tcon("Foo", [], ctx)));
+
+      const expr: Expr = sb.mem("foo", "bar");
+
+      expect(() =>
+        inferExpr(env, expr, ctx.state)
+      ).toThrowErrorMatchingInlineSnapshot(
+        `"Can't use member access on TPrim"`
+      );
+    });
+
+    test("property doesn't exist on aliased TRec type", () => {
+      const ctx = tb.createCtx();
+      let env: Env = Map();
+      env = env.set("Foo", scheme([], tb.trec([], ctx)));
+      env = env.set("foo", scheme([], tb.tcon("Foo", [], ctx)));
+
+      const expr: Expr = sb.mem("foo", "bar");
+
+      expect(() =>
+        inferExpr(env, expr, ctx.state)
+      ).toThrowErrorMatchingInlineSnapshot(
+        `"bar property doesn't exist on {}"`
+      );
+    });
+
+    test("access on TPrim stored in TVar throws", () => {
+      const ctx = tb.createCtx();
+      let env: Env = Map();
+      env = env.set("foo", scheme([], tb.tNum(ctx)));
+
+      const expr: Expr = sb.mem("foo", "bar");
+
+      expect(() =>
+        inferExpr(env, expr, ctx.state)
+      ).toThrowErrorMatchingInlineSnapshot(
+        `"Can't use member access on TPrim"`
+      );
+    });
+  });
 
   // TODO: test TMem type once it's been created
 

--- a/write-you-a-haskell/src/__tests__/record.test.ts
+++ b/write-you-a-haskell/src/__tests__/record.test.ts
@@ -4,7 +4,8 @@ import { inferExpr } from "../infer";
 import { Expr } from "../syntax-types";
 import * as sb from "../syntax-builders";
 import * as tb from "../type-builders";
-import { Env, freeze, print, scheme, Scheme } from "../type-types";
+import { Env } from "../context";
+import { freeze, print, scheme, Scheme } from "../type-types";
 
 describe("record", () => {
   test("can infer a tuple containing different types", () => {

--- a/write-you-a-haskell/src/__tests__/tuple.test.ts
+++ b/write-you-a-haskell/src/__tests__/tuple.test.ts
@@ -71,9 +71,7 @@ describe("tuple", () => {
         sb.tuple([sb.num(5), sb.str("hello"), sb.bool(true)]),
       ]);
 
-      expect(() => inferExpr(env, expr)).toThrowErrorMatchingInlineSnapshot(
-        `"Couldn't unify [b, c] with [5, \\"hello\\", true]"`
-      );
+      expect(() => inferExpr(env, expr)).toThrowErrorMatchingInlineSnapshot(`"Couldn't unify [a, b] with [5, \\"hello\\", true]"`);
     });
 
     test("arg tuple has few many elements", () => {
@@ -82,9 +80,7 @@ describe("tuple", () => {
 
       const expr: Expr = sb.app(sb._var("snd"), [sb.tuple([sb.num(5)])]);
 
-      expect(() => inferExpr(env, expr)).toThrowErrorMatchingInlineSnapshot(
-        `"Couldn't unify [b, c] with [5]"`
-      );
+      expect(() => inferExpr(env, expr)).toThrowErrorMatchingInlineSnapshot(`"Couldn't unify [a, b] with [5]"`);
     });
 
     test("element mismatch", () => {

--- a/write-you-a-haskell/src/__tests__/tuple.test.ts
+++ b/write-you-a-haskell/src/__tests__/tuple.test.ts
@@ -4,7 +4,8 @@ import { inferExpr } from "../infer";
 import { Expr } from "../syntax-types";
 import * as sb from "../syntax-builders";
 import * as tb from "../type-builders";
-import { Env, freeze, print, scheme, Scheme } from "../type-types";
+import { Env } from "../context";
+import { freeze, print, scheme, Scheme } from "../type-types";
 
 describe("tuple", () => {
   test("can infer a tuple containing different types", () => {

--- a/write-you-a-haskell/src/__tests__/union.test.ts
+++ b/write-you-a-haskell/src/__tests__/union.test.ts
@@ -3,7 +3,8 @@ import { Map } from "immutable";
 import { inferExpr } from "../infer";
 import { computeUnion } from "../constraint-solver";
 import { Expr } from "../syntax-types";
-import { Env, print, scheme } from "../type-types";
+import { Env } from "../context";
+import { print, scheme } from "../type-types";
 import * as sb from "../syntax-builders";
 import * as tb from "../type-builders";
 

--- a/write-you-a-haskell/src/constraint-solver.ts
+++ b/write-you-a-haskell/src/constraint-solver.ts
@@ -302,6 +302,24 @@ export const computeUnion = (
   //   if each element is a subtype of T then a tuple of those elements is a subtype
   //   of Array<T>.
   //   NOTE: TypeScript doesn't do this yet.
+  // - need to introduce type aliases to model Array<T>, Promise<T>, etc.
+  //   in particular we want to support the following:
+  //   type Array<T> = {
+  //     get length: number,
+  //     map: <U>((T, number, Array<T>) => U) => Array<U>,
+  //     ...
+  //   }
+  // - start by trying to build a type that represents the rhs, it should look
+  //   something like:
+  //   <T>{lenght: number, map: <U>((T, number, Array<T>) => U) => Array<U>}
+  //
+  // What do we want to do about element access on arrays?
+  // 1. return Maybe<T> (or T | undefined) and force people to check the result
+  // 2. have a version that throws if we exceed the bounds of the array
+  // 3. have an unsafe version that silently return undefined if we exceed the bounds
+  //
+  // Rescript does 2.
+  // TypeScript does 3.
 
   const filteredTypes = [...primTypes, ...litTypes];
 

--- a/write-you-a-haskell/src/constraint-solver.ts
+++ b/write-you-a-haskell/src/constraint-solver.ts
@@ -143,6 +143,9 @@ const unifyFuncs = (t1: t.TFun, t2: t.TFun, ctx: t.Context): t.Subst => {
     }
   }
 
+  t1.ret; // ?
+  t2.ret; // ?
+
   // TODO: add support for optional params
   // we can model optional params as union types, e.g. int | void
   return unifyMany([...t1.args, t1.ret], [...t2.args, t2.ret], ctx);

--- a/write-you-a-haskell/src/context.ts
+++ b/write-you-a-haskell/src/context.ts
@@ -1,0 +1,60 @@
+import { Map } from "immutable";
+
+import { apply, zip } from "./util";
+import { UnboundVariable } from "./errors";
+import { Scheme, Type, TVar } from "./type-types";
+
+// Env is a map of all the current schemes (qualified types) that
+// are in scope.
+export type Env = Map<string, Scheme>;
+
+export type State = {
+  count: number;
+};
+
+export type Context = {
+  env: Env;
+  state: State;
+  async?: boolean;
+};
+
+export const lookupEnv = (name: string, ctx: Context): Type => {
+  const value = ctx.env.get(name);
+  if (!value) {
+    // TODO: keep track of all unbound variables in a decl
+    // we can return `unknown` as the type so that unifcation
+    // can continue.
+    throw new UnboundVariable(name);
+  }
+  return instantiate(value, ctx);
+};
+
+const instantiate = (sc: Scheme, ctx: Context): Type => {
+  const freshQualifiers = sc.qualifiers.map(() => fresh(ctx));
+  const subs = Map(
+    zip(
+      sc.qualifiers.map((qual) => qual.id),
+      freshQualifiers
+    )
+  );
+  return apply(subs, sc.type);
+};
+
+export const fresh = (ctx: Context): TVar => {
+  const id = newId(ctx);
+  // ctx.state.count++;
+  return {
+    tag: "TVar",
+    id: id,
+    name: letterFromIndex(id),
+  };
+};
+
+const letterFromIndex = (index: number): string =>
+  String.fromCharCode(97 + index);
+
+export const newId = (ctx: Context): number => {
+  const id = ctx.state.count++;
+  // console.log(`id = ${id}`);
+  return id;
+};

--- a/write-you-a-haskell/src/syntax-builders.ts
+++ b/write-you-a-haskell/src/syntax-builders.ts
@@ -44,6 +44,12 @@ export const prop = (name: string, value: t.Expr): t.EProp => ({
   name,
   value,
 });
+export const mem = (object: string, property: string): t.EMem => ({
+  tag: "Mem",
+  // This is just a convenience for now.
+  object: _var(object),
+  property: _var(property),
+});
 
 export const num = (value: number): t.ELit => ({
   tag: "Lit",

--- a/write-you-a-haskell/src/syntax-types.ts
+++ b/write-you-a-haskell/src/syntax-types.ts
@@ -14,9 +14,10 @@ export type ELam = { tag: "Lam"; args: readonly string[]; body: Expr; async?: bo
 export type ELet = { tag: "Let"; pattern: Pattern; value: Expr; body: Expr };
 export type ELit = { tag: "Lit"; value: Literal };
 export type EOp = { tag: "Op"; op: Binop; left: Expr; right: Expr };
-export type ERec = { tag: "Rec"; properties: readonly EProp[] };
+export type ERec = { tag: "Rec"; properties: readonly EProp[] }; // rename to EObj
 export type ETuple = { tag: "Tuple"; elements: readonly Expr[] };
-export type EVar = { tag: "Var"; name: string };
+export type EVar = { tag: "Var"; name: string }; // rename to EIdent?
+export type EMem = { tag: "Mem"; object: Expr; property: Expr };
 
 export type Expr =
   | EApp
@@ -29,7 +30,8 @@ export type Expr =
   | EOp
   | ERec
   | ETuple
-  | EVar;
+  | EVar
+  | EMem;
 
 export type EProp = { tag: "EProp"; name: string; value: Expr };
 

--- a/write-you-a-haskell/src/type-builders.ts
+++ b/write-you-a-haskell/src/type-builders.ts
@@ -3,7 +3,11 @@ import { Map } from "immutable";
 import { Literal } from "./syntax-types";
 import * as t from "./type-types";
 
-export const newId = (ctx: t.Context): number => ++ctx.state.count;
+export const newId = (ctx: t.Context): number => {
+  const id = ctx.state.count++;
+  // console.log(`id = ${id}`);
+  return id;
+}
 
 export const tvar = (name: string, ctx: t.Context): t.TVar => ({
   tag: "TVar",

--- a/write-you-a-haskell/src/type-builders.ts
+++ b/write-you-a-haskell/src/type-builders.ts
@@ -3,7 +3,7 @@ import { Map } from "immutable";
 import { Literal } from "./syntax-types";
 import * as t from "./type-types";
 
-const newId = (ctx: t.Context): number => ++ctx.state.count;
+export const newId = (ctx: t.Context): number => ++ctx.state.count;
 
 export const tvar = (name: string, ctx: t.Context): t.TVar => ({
   tag: "TVar",

--- a/write-you-a-haskell/src/type-builders.ts
+++ b/write-you-a-haskell/src/type-builders.ts
@@ -1,15 +1,10 @@
 import { Map } from "immutable";
 
 import { Literal } from "./syntax-types";
+import { Context, newId } from "./context";
 import * as t from "./type-types";
 
-export const newId = (ctx: t.Context): number => {
-  const id = ctx.state.count++;
-  // console.log(`id = ${id}`);
-  return id;
-}
-
-export const tvar = (name: string, ctx: t.Context): t.TVar => ({
+export const tvar = (name: string, ctx: Context): t.TVar => ({
   tag: "TVar",
   id: newId(ctx),
   name,
@@ -18,7 +13,7 @@ export const tvar = (name: string, ctx: t.Context): t.TVar => ({
 export const tcon = (
   name: string,
   params: readonly t.Type[],
-  ctx: t.Context
+  ctx: Context
 ): t.TCon => ({
   tag: "TCon",
   id: newId(ctx),
@@ -29,7 +24,7 @@ export const tcon = (
 export const tfun = (
   args: readonly t.Type[],
   ret: t.Type,
-  ctx: t.Context,
+  ctx: Context,
   src?: "App" | "Fix" | "Lam"
 ): t.TFun => ({
   tag: "TFun",
@@ -39,22 +34,19 @@ export const tfun = (
   src,
 });
 
-export const tunion = (types: readonly t.Type[], ctx: t.Context): t.TUnion => ({
+export const tunion = (types: readonly t.Type[], ctx: Context): t.TUnion => ({
   tag: "TUnion",
   id: newId(ctx),
   types,
 });
 
-export const ttuple = (types: readonly t.Type[], ctx: t.Context): t.TTuple => ({
+export const ttuple = (types: readonly t.Type[], ctx: Context): t.TTuple => ({
   tag: "TTuple",
   id: newId(ctx),
   types,
 });
 
-export const trec = (
-  properties: readonly t.TProp[],
-  ctx: t.Context
-): t.TRec => ({
+export const trec = (properties: readonly t.TProp[], ctx: Context): t.TRec => ({
   tag: "TRec",
   id: newId(ctx),
   properties,
@@ -66,26 +58,26 @@ export const tprop = (name: string, type: t.Type): t.TProp => ({
   type,
 });
 
-export const createCtx = (): t.Context => {
-  const ctx: t.Context = {
+export const createCtx = (): Context => {
+  const ctx: Context = {
     env: Map(),
     state: { count: 0 },
   };
   return ctx;
 };
 
-export const tprim = (name: t.PrimName, ctx: t.Context): t.TPrim => ({
+export const tprim = (name: t.PrimName, ctx: Context): t.TPrim => ({
   tag: "TPrim",
   id: newId(ctx),
   name,
 });
 
-export const tNum = (ctx: t.Context): t.TPrim => tprim("number", ctx);
-export const tStr = (ctx: t.Context): t.TPrim => tprim("string", ctx);
-export const tBool = (ctx: t.Context): t.TPrim => tprim("boolean", ctx);
+export const tNum = (ctx: Context): t.TPrim => tprim("number", ctx);
+export const tStr = (ctx: Context): t.TPrim => tprim("string", ctx);
+export const tBool = (ctx: Context): t.TPrim => tprim("boolean", ctx);
 
-export const tlit = (lit: Literal, ctx: t.Context): t.TLit => ({
+export const tlit = (lit: Literal, ctx: Context): t.TLit => ({
   tag: "TLit",
   id: newId(ctx),
   value: lit,
-})
+});

--- a/write-you-a-haskell/src/type-types.ts
+++ b/write-you-a-haskell/src/type-types.ts
@@ -139,21 +139,7 @@ export const isTPrim = (t: Type): t is TPrim => t.tag === "TPrim";
 export const isTLit = (t: Type): t is TLit => t.tag === "TLit";
 export const isScheme = (t: any): t is Scheme => t.tag === "Forall";
 
-// Env is a map of all the current schemes (qualified types) that
-// are in scope.
-export type Env = Map<string, Scheme>;
-
 export type Constraint = readonly [Type, Type];
 export type Unifier = readonly [Subst, readonly Constraint[]];
 
 export type Subst = Map<number, Type>;
-
-export type State = {
-  count: number;
-};
-
-export type Context = {
-  env: Env;
-  state: State;
-  async?: boolean;
-};

--- a/write-you-a-haskell/src/util.ts
+++ b/write-you-a-haskell/src/util.ts
@@ -1,6 +1,7 @@
 import { Map, Set } from "immutable";
 
-import { Type, TVar, Subst, Constraint, Scheme, Env, isTLit } from "./type-types";
+import { Env } from "./context";
+import { Type, TVar, Subst, Constraint, Scheme, isTLit } from "./type-types";
 import {
   isTCon,
   isTVar,


### PR DESCRIPTION
TODO:
- [x] instantiate type returned by `inferMem`
- [x] add more tests, e.g. pass a callback to `strArray.map()`