### PR TITLE
Impove subtyping

### DIFF
--- a/write-you-a-haskell/src/__tests__/function.test.ts
+++ b/write-you-a-haskell/src/__tests__/function.test.ts
@@ -291,7 +291,7 @@ describe("function subtyping", () => {
         [
           eng.tcon("Array", [aVar]),
           // Why is this TFun's `src` an "App"?
-          eng.tfun([aVar, eng.tprim("number")], bVar, "App"),
+          eng.tfun([aVar, eng.tprim("number")], bVar),
         ],
         eng.tcon("Array", [bVar])
       )
@@ -343,7 +343,7 @@ describe("function subtyping", () => {
       eng.tfun(
         [
           eng.tcon("Array", [aVar]),
-          eng.tfun([aVar, eng.tprim("number")], bVar, "App"),
+          eng.tfun([aVar, eng.tprim("number")], bVar),
         ],
         eng.tcon("Array", [bVar])
       )

--- a/write-you-a-haskell/src/__tests__/infer.test.ts
+++ b/write-you-a-haskell/src/__tests__/infer.test.ts
@@ -169,7 +169,7 @@ describe("inferExpr", () => {
       // <a>(a) => Promise<a>
       const promisifyScheme = scheme(
         [aVar],
-        eng.tfun([aVar], eng.tcon("Promise", [aVar]), "Lam")
+        eng.tfun([aVar], eng.tcon("Promise", [aVar]))
       );
 
       eng.defScheme("promisify", promisifyScheme);
@@ -194,7 +194,7 @@ describe("inferExpr", () => {
       // <a>(Foo<a>) => a
       const extractScheme = scheme(
         [aVar],
-        eng.tfun([eng.tcon("Foo", [aVar])], aVar, "Lam")
+        eng.tfun([eng.tcon("Foo", [aVar])], aVar)
       );
 
       eng.defScheme("extract", extractScheme);
@@ -217,7 +217,7 @@ describe("inferExpr", () => {
       // <a>(Foo<a>) => a
       const extractScheme = scheme(
         [aVar],
-        eng.tfun([eng.tcon("Foo", [aVar])], aVar, "Lam")
+        eng.tfun([eng.tcon("Foo", [aVar])], aVar)
       );
 
       eng.defScheme("extract", extractScheme);

--- a/write-you-a-haskell/src/__tests__/infer.test.ts
+++ b/write-you-a-haskell/src/__tests__/infer.test.ts
@@ -262,7 +262,7 @@ describe("inferExpr", () => {
       // TODO: improve this error so that it says something like:
       // Can't pass `true` where the `+` operator expects a `number`
       expect(() => eng.inferExpr(expr)).toThrowErrorMatchingInlineSnapshot(
-        `"Couldn't unify number with true"`
+        `"true is not a subtype of number"`
       );
     });
 

--- a/write-you-a-haskell/src/__tests__/record.test.ts
+++ b/write-you-a-haskell/src/__tests__/record.test.ts
@@ -122,7 +122,7 @@ describe("record", () => {
       ]);
 
       expect(() => eng.inferExpr(expr)).toThrowErrorMatchingInlineSnapshot(
-        `"Couldn't unify string with true"`
+        `"true is not a subtype of string"`
       );
     });
   });

--- a/write-you-a-haskell/src/__tests__/tuple.test.ts
+++ b/write-you-a-haskell/src/__tests__/tuple.test.ts
@@ -85,12 +85,6 @@ describe("tuple", () => {
 
     test("element mismatch", () => {
       const eng = new Engine();
-      const aVar = eng.tvar("a");
-      const bVar = eng.tvar("b");
-      const snd: Scheme = scheme(
-        [aVar, bVar],
-        eng.tfun([eng.ttuple([aVar, bVar])], bVar)
-      );
       const foo: Scheme = scheme(
         [],
         eng.tfun(
@@ -111,5 +105,59 @@ describe("tuple", () => {
     });
   });
 
-  // TODO: tuple subtyping
+  describe("subtyping", () => {
+    test("[5, 5] is a subtype of Array<5>", () => {
+      const eng = new Engine();
+      eng.defType(
+        "foo",
+        eng.tfun(
+          [eng.tcon("Array", [eng.tlit({ tag: "LNum", value: 5 })])],
+          eng.tprim("number"),
+          "Lam",
+        )
+      );
+
+      expect(() =>
+        eng.inferExpr(
+          sb.app(sb._var("foo"), [sb.tuple([sb.num(5), sb.num(5)])])
+        )
+      ).not.toThrow();
+    });
+
+    test("[1, 2, 3] is a subtype of Array<number>", () => {
+      const eng = new Engine();
+      eng.defType(
+        "foo",
+        eng.tfun(
+          [eng.tcon("Array", [eng.tprim("number")])],
+          eng.tprim("number")
+        )
+      );
+
+      expect(() =>
+        eng.inferExpr(
+          sb.app(sb._var("foo"), [sb.tuple([sb.num(1), sb.num(2), sb.num(3)])])
+        )
+      ).not.toThrow();
+    });
+
+    test("Array<number> is not a subtype of [5, 10]", () => {
+      const eng = new Engine();
+      eng.defType(
+        "foo",
+        eng.tfun(
+          [eng.ttuple([eng.tlit({tag: "LNum", value: 5}), eng.tlit({tag: "LNum", value: 10})])],
+          eng.tprim("number"),
+          "Lam",
+        )
+      );
+      eng.defType("numArray", eng.tcon("Array", [eng.tprim("number")]));
+
+      expect(() =>
+        eng.inferExpr(
+          sb.app(sb._var("foo"), [sb._var("numArray")])
+        )
+      ).not.toThrow();
+    });
+  });
 });

--- a/write-you-a-haskell/src/__tests__/tuple.test.ts
+++ b/write-you-a-haskell/src/__tests__/tuple.test.ts
@@ -61,7 +61,7 @@ describe("tuple", () => {
 
       // TODO: fix message to use [a, b] instead of [e, f];
       expect(() => eng.inferExpr(expr)).toThrowErrorMatchingInlineSnapshot(
-        `"Couldn't unify [e, f] with [5, \\"hello\\", true]"`
+        `"Couldn't unify [5, \\"hello\\", true] with [e, f]"`
       );
     });
 
@@ -79,7 +79,7 @@ describe("tuple", () => {
 
       // TODO: fix message to use [a, b] instead of [e, f];
       expect(() => eng.inferExpr(expr)).toThrowErrorMatchingInlineSnapshot(
-        `"Couldn't unify [e, f] with [5]"`
+        `"Couldn't unify [5] with [e, f]"`
       );
     });
 
@@ -112,8 +112,7 @@ describe("tuple", () => {
         "foo",
         eng.tfun(
           [eng.tcon("Array", [eng.tlit({ tag: "LNum", value: 5 })])],
-          eng.tprim("number"),
-          "Lam"
+          eng.tprim("number")
         )
       );
 
@@ -152,8 +151,7 @@ describe("tuple", () => {
               eng.tlit({ tag: "LNum", value: 10 }),
             ]),
           ],
-          eng.tprim("number"),
-          "Lam"
+          eng.tprim("number")
         )
       );
       eng.defType("numArray", eng.tcon("Array", [eng.tprim("number")]));

--- a/write-you-a-haskell/src/__tests__/tuple.test.ts
+++ b/write-you-a-haskell/src/__tests__/tuple.test.ts
@@ -100,7 +100,7 @@ describe("tuple", () => {
       ]);
 
       expect(() => eng.inferExpr(expr)).toThrowErrorMatchingInlineSnapshot(
-        `"Couldn't unify string with true"`
+        `"true is not a subtype of string"`
       );
     });
   });
@@ -113,7 +113,7 @@ describe("tuple", () => {
         eng.tfun(
           [eng.tcon("Array", [eng.tlit({ tag: "LNum", value: 5 })])],
           eng.tprim("number"),
-          "Lam",
+          "Lam"
         )
       );
 
@@ -146,18 +146,23 @@ describe("tuple", () => {
       eng.defType(
         "foo",
         eng.tfun(
-          [eng.ttuple([eng.tlit({tag: "LNum", value: 5}), eng.tlit({tag: "LNum", value: 10})])],
+          [
+            eng.ttuple([
+              eng.tlit({ tag: "LNum", value: 5 }),
+              eng.tlit({ tag: "LNum", value: 10 }),
+            ]),
+          ],
           eng.tprim("number"),
-          "Lam",
+          "Lam"
         )
       );
       eng.defType("numArray", eng.tcon("Array", [eng.tprim("number")]));
 
       expect(() =>
-        eng.inferExpr(
-          sb.app(sb._var("foo"), [sb._var("numArray")])
-        )
-      ).not.toThrow();
+        eng.inferExpr(sb.app(sb._var("foo"), [sb._var("numArray")]))
+      ).toThrowErrorMatchingInlineSnapshot(
+        `"Array<number> is not a subtype of [5, 10]"`
+      );
     });
   });
 });

--- a/write-you-a-haskell/src/__tests__/union.test.ts
+++ b/write-you-a-haskell/src/__tests__/union.test.ts
@@ -153,7 +153,7 @@ describe("Union types and type widening", () => {
     // `add` was inferred to have type `(number, number) => number` so
     // we can't pass it a boolean, in this case, `true`
     expect(() => eng.inferExpr(expr)).toThrowErrorMatchingInlineSnapshot(
-      `"Couldn't unify number with true"`
+      `"true is not a subtype of number"`
     );
   });
 
@@ -194,7 +194,6 @@ describe("Union types and type widening", () => {
       expect(print(result)).toEqual("boolean");
     });
 
-
     test("true | false => boolean", () => {
       const eng = new Engine();
       const litTrue = eng.tlit({ tag: "LBool", value: true });
@@ -215,7 +214,7 @@ describe("Union types and type widening", () => {
 
     test('"hello" | string => string', () => {
       const eng = new Engine();
-      const hello = eng.tlit({tag: "LStr", value: "hello"});
+      const hello = eng.tlit({ tag: "LStr", value: "hello" });
       const str = eng.tprim("string");
       const result = computeUnion(hello, str, eng.ctx);
 
@@ -224,8 +223,8 @@ describe("Union types and type widening", () => {
 
     test('"hello" | "world" => string', () => {
       const eng = new Engine();
-      const hello = eng.tlit({tag: "LStr", value: "hello"});
-      const world = eng.tlit({tag: "LStr", value: "world"});
+      const hello = eng.tlit({ tag: "LStr", value: "hello" });
+      const world = eng.tlit({ tag: "LStr", value: "world" });
       const result = computeUnion(hello, world, eng.ctx);
 
       expect(print(result)).toEqual('"hello" | "world"');

--- a/write-you-a-haskell/src/__tests__/union.test.ts
+++ b/write-you-a-haskell/src/__tests__/union.test.ts
@@ -60,7 +60,7 @@ describe("Union types and type widening", () => {
 
     const result = eng.inferExpr(expr);
     expect(print(result)).toMatchInlineSnapshot(
-      `"<a>(boolean, (5 | true) => a) => a"`
+      `"<a>(boolean, (true | 5) => a) => a"`
     );
   });
 
@@ -136,7 +136,7 @@ describe("Union types and type widening", () => {
     const result = eng.inferExpr(expr);
 
     expect(print(result)).toMatchInlineSnapshot(
-      `"<a>((5 | true | \\"hello\\") => a) => a"`
+      `"<a>((\\"hello\\" | true | 5) => a) => a"`
     );
   });
 

--- a/write-you-a-haskell/src/builtins.ts
+++ b/write-you-a-haskell/src/builtins.ts
@@ -3,45 +3,39 @@ import { Scheme, scheme, freeze } from "./type-types";
 import * as tb from "./type-builders";
 
 export const createArrayScheme = (ctx: Context): Scheme => {
-    const tVar = tb.tvar("T", ctx);
-    const uVar = tb.tvar("U", ctx);
-    const sc = scheme(
-      [tVar],
-      tb.trec(
-        [
-          tb.tprop("length", tb.tprim("number", ctx)),
-          tb.tprop(
-            "map",
-            // TODO: properties need to be able to accept Schemes
-            // as well as types.
-            tb.tfun(
-              [
-                tb.tfun(
-                  [
-                    tVar,
-                    tb.tprim("number", ctx),
-                    // TODO: how do we handle record types that
-                    // reference themselves.
-                    tb.tcon("Array", [tVar], ctx),
-                  ],
-                  uVar,
-                  ctx,
-                  // TODO: come up with better 'src' names
-                  // perhaps 'use' is better than 'src'
-                  // This could maybe be 'Param' or 'Arg'
-                  "App", // why does this use "App"?
-                ),
-              ],
-              tb.tcon("Array", [uVar], ctx),
-              ctx,
-              "Lam",
-            )
-          ),
-        ],
-        ctx
-      )
-    );
-    freeze(sc.type);
-    return sc;
-  };
-  
+  const tVar = tb.tvar("T", ctx);
+  const uVar = tb.tvar("U", ctx);
+  const sc = scheme(
+    [tVar],
+    tb.trec(
+      [
+        tb.tprop("length", tb.tprim("number", ctx)),
+        tb.tprop(
+          "map",
+          // TODO: properties need to be able to accept Schemes
+          // as well as types.
+          tb.tfun(
+            [
+              tb.tfun(
+                [
+                  tVar,
+                  tb.tprim("number", ctx),
+                  // TODO: how do we handle record types that
+                  // reference themselves.
+                  tb.tcon("Array", [tVar], ctx),
+                ],
+                uVar,
+                ctx
+              ),
+            ],
+            tb.tcon("Array", [uVar], ctx),
+            ctx
+          )
+        ),
+      ],
+      ctx
+    )
+  );
+  freeze(sc.type);
+  return sc;
+};

--- a/write-you-a-haskell/src/constraint-solver.ts
+++ b/write-you-a-haskell/src/constraint-solver.ts
@@ -4,7 +4,7 @@ import { assert } from "console";
 import { Context, lookupEnv } from "./context";
 import * as t from "./type-types";
 import * as tb from "./type-builders";
-import { apply, ftv, zip, zipTypes } from "./util";
+import { apply, ftv, zipTypes } from "./util";
 import {
   InfiniteType,
   UnificationFail,
@@ -109,10 +109,7 @@ export const unifies = (c: t.Constraint, ctx: Context): t.Subst => {
     }
   }
 
-  if (subtype === "Left" && isSubType(t1, t2)) {
-    return emptySubst;
-  }
-  if (subtype === "Right" && isSubType(t2, t1)) {
+  if (subtype && isSubType(t1, t2)) {
     return emptySubst;
   }
 
@@ -123,11 +120,8 @@ export const unifies = (c: t.Constraint, ctx: Context): t.Subst => {
     return widenTypes(t1, t2, ctx);
   }
 
-  if (subtype === "Left") {
+  if (subtype) {
     throw new SubtypingFailure(t1, t2);
-  }
-  if (subtype === "Right") {
-    throw new SubtypingFailure(t2, t1);
   }
 
   throw new UnificationFail(t1, t2);
@@ -136,48 +130,23 @@ export const unifies = (c: t.Constraint, ctx: Context): t.Subst => {
 const unifyFuncs = (c: t.Constraint<t.TFun>, ctx: Context): t.Subst => {
   const [t1, t2] = c.types;
 
-  // infer() only ever creates a Lam node on the left side of a constraint
-  // and an App on the right side of a constraint so this check is sufficient.
-  if (c.subtype === "Right") {
-    // partial application
-    if (t1.args.length > t2.args.length) {
-      const t1_partial: t.Type = {
-        tag: "TFun",
-        id: t1.id, // is it safe to reuse `id` here?
-        args: t1.args.slice(0, t2.args.length),
-        ret: tb.tfun(t1.args.slice(t2.args.length), t1.ret, ctx),
-      };
-      const constraints: readonly t.Constraint[] = [
-        ...zipTypes(t1_partial.args, t2.args, c.subtype, true),
-        { types: [t1_partial.ret, t2.ret], subtype: c.subtype },
-      ];
-      return unifyMany(constraints, ctx);
-    }
-
-    // subtyping: we ignore extra args
-    // TODO: Create a `isSubType` helper function
-    // TODO: update this once we support rest params
-    if (t1.args.length < t2.args.length) {
-      const t2_without_extra_args: t.Type = {
-        tag: "TFun",
-        id: t2.id, // is it safe to reuse `id` here?
-        args: t2.args.slice(0, t1.args.length),
-        ret: t2.ret,
-      };
-      const constraints: readonly t.Constraint[] = [
-        ...zipTypes(t1.args, t2_without_extra_args.args, c.subtype, true),
-        { types: [t1.ret, t2_without_extra_args.ret], subtype: c.subtype },
-      ];
-      return unifyMany(constraints, ctx);
-    }
+  // partial application
+  if (t1.args.length < t2.args.length) {
+    const t2_partial: t.Type = {
+      tag: "TFun",
+      id: t2.id, // is it safe to reuse `id` here?
+      args: t2.args.slice(0, t1.args.length),
+      ret: tb.tfun(t2.args.slice(t1.args.length), t2.ret, ctx),
+    };
+    const constraints: readonly t.Constraint[] = [
+      ...zipTypes(t1.args, t2_partial.args, c.subtype, true),
+      { types: [t1.ret, t2_partial.ret], subtype: c.subtype },
+    ];
+    return unifyMany(constraints, ctx);
   }
 
-  // The reverse can happen when a callback is passed as an arg
-  if (c.subtype === "Left") {
-    // Can partial application happen in this situation?
-
+  if (c.subtype) {
     // subtyping: we ignore extra args
-    // TODO: Create a `isSubType` helper function
     // TODO: update this once we support rest params
     if (t1.args.length > t2.args.length) {
       const t1_without_extra_args: t.Type = {
@@ -198,15 +167,6 @@ const unifyFuncs = (c: t.Constraint<t.TFun>, ctx: Context): t.Subst => {
   // we can model optional params as union types, e.g. int | void
   if (t1.args.length !== t2.args.length) {
     throw new UnificationMismatch(t1.args, t2.args);
-  }
-
-  if (c.subtype) {
-    const constraints: readonly t.Constraint[] = [
-      ...zipTypes(t1.args, t2.args, c.subtype, true),
-      { types: [t1.ret, t2.ret], subtype: c.subtype },
-    ];
-
-    return unifyMany(constraints, ctx);
   }
 
   const constraints: readonly t.Constraint[] = [

--- a/write-you-a-haskell/src/constraint-solver.ts
+++ b/write-you-a-haskell/src/constraint-solver.ts
@@ -138,7 +138,7 @@ const unifyFuncs = (c: t.Constraint<t.TFun>, ctx: Context): t.Subst => {
 
   // infer() only ever creates a Lam node on the left side of a constraint
   // and an App on the right side of a constraint so this check is sufficient.
-  if (t1.src === "Lam" && t2.src === "App") {
+  if (c.subtype === "Right") {
     // partial application
     if (t1.args.length > t2.args.length) {
       const t1_partial: t.Type = {
@@ -146,10 +146,9 @@ const unifyFuncs = (c: t.Constraint<t.TFun>, ctx: Context): t.Subst => {
         id: t1.id, // is it safe to reuse `id` here?
         args: t1.args.slice(0, t2.args.length),
         ret: tb.tfun(t1.args.slice(t2.args.length), t1.ret, ctx),
-        src: t1.src,
       };
       const constraints: readonly t.Constraint[] = [
-        ...zipTypes(t1_partial.args, t2.args, c.subtype),
+        ...zipTypes(t1_partial.args, t2.args, c.subtype, true),
         { types: [t1_partial.ret, t2.ret], subtype: c.subtype },
       ];
       return unifyMany(constraints, ctx);
@@ -164,10 +163,9 @@ const unifyFuncs = (c: t.Constraint<t.TFun>, ctx: Context): t.Subst => {
         id: t2.id, // is it safe to reuse `id` here?
         args: t2.args.slice(0, t1.args.length),
         ret: t2.ret,
-        src: t2.src,
       };
       const constraints: readonly t.Constraint[] = [
-        ...zipTypes(t1.args, t2_without_extra_args.args, c.subtype),
+        ...zipTypes(t1.args, t2_without_extra_args.args, c.subtype, true),
         { types: [t1.ret, t2_without_extra_args.ret], subtype: c.subtype },
       ];
       return unifyMany(constraints, ctx);
@@ -175,7 +173,7 @@ const unifyFuncs = (c: t.Constraint<t.TFun>, ctx: Context): t.Subst => {
   }
 
   // The reverse can happen when a callback is passed as an arg
-  if (t1.src === "App" && t2.src === "Lam") {
+  if (c.subtype === "Left") {
     // Can partial application happen in this situation?
 
     // subtyping: we ignore extra args
@@ -187,10 +185,9 @@ const unifyFuncs = (c: t.Constraint<t.TFun>, ctx: Context): t.Subst => {
         id: t1.id, // is it safe to reuse `id` here?
         args: t1.args.slice(0, t2.args.length),
         ret: t1.ret,
-        src: t1.src,
       };
       const constraints: readonly t.Constraint[] = [
-        ...zipTypes(t1_without_extra_args.args, t2.args, c.subtype),
+        ...zipTypes(t1_without_extra_args.args, t2.args, c.subtype, true),
         { types: [t1_without_extra_args.ret, t2.ret], subtype: c.subtype },
       ];
       return unifyMany(constraints, ctx);
@@ -205,7 +202,7 @@ const unifyFuncs = (c: t.Constraint<t.TFun>, ctx: Context): t.Subst => {
 
   if (c.subtype) {
     const constraints: readonly t.Constraint[] = [
-      ...zipTypes(t1.args, t2.args, c.subtype),
+      ...zipTypes(t1.args, t2.args, c.subtype, true),
       { types: [t1.ret, t2.ret], subtype: c.subtype },
     ];
 
@@ -213,7 +210,7 @@ const unifyFuncs = (c: t.Constraint<t.TFun>, ctx: Context): t.Subst => {
   }
 
   const constraints: readonly t.Constraint[] = [
-    ...zipTypes(t1.args, t2.args, c.subtype),
+    ...zipTypes(t1.args, t2.args, c.subtype, true),
     { types: [t1.ret, t2.ret], subtype: c.subtype },
   ];
 

--- a/write-you-a-haskell/src/engine.ts
+++ b/write-you-a-haskell/src/engine.ts
@@ -38,8 +38,8 @@ export class Engine {
     return tb.tcon(name, params, this.ctx);
   }
 
-  tfun(args: readonly t.Type[], ret: t.Type, src?: "App" | "Fix" | "Lam") {
-    return tb.tfun(args, ret, this.ctx, src);
+  tfun(args: readonly t.Type[], ret: t.Type) {
+    return tb.tfun(args, ret, this.ctx);
   }
 
   tunion(types: readonly t.Type[]) {

--- a/write-you-a-haskell/src/errors.ts
+++ b/write-you-a-haskell/src/errors.ts
@@ -8,6 +8,14 @@ export class UnificationFail extends Error {
   }
 }
 
+export class SubtypingFailure extends Error {
+  constructor(sub: Type, sup: Type) {
+    const message = `${print(sub)} is not a subtype of ${print(sup)}`;
+    super(message);
+    this.name = "SubtypingFailure";
+  }
+}
+
 export class InfiniteType extends Error {
   constructor(a: TVar, b: Type) {
     const message = `${print(a)} appears in ${print(b)}`;
@@ -27,7 +35,7 @@ export class UnboundVariable extends Error {
 export class Ambiguous extends Error {
   constructor(constraints: Constraint[]) {
     const message = constraints
-      .map(([a, b]) => `${print(a)} = ${print(b)}`)
+      .map(({types: [a, b]}) => `${print(a)} = ${print(b)}`)
       .join(", ");
     super(message);
     this.name = "Ambiguous";

--- a/write-you-a-haskell/src/infer.ts
+++ b/write-you-a-haskell/src/infer.ts
@@ -10,7 +10,11 @@ import * as tb from "./type-builders";
 
 const emptyEnv: Env = Map();
 
-export const inferExpr = (env: Env, expr: st.Expr, state?: State): tt.Scheme => {
+export const inferExpr = (
+  env: Env,
+  expr: st.Expr,
+  state?: State
+): tt.Scheme => {
   const initCtx: Context = {
     env: env,
     state: state || { count: 0 },
@@ -64,7 +68,9 @@ const normalize = (sc: tt.Scheme): tt.Scheme => {
   const values: tt.TVar[] = keys.map((key, index) => {
     return { tag: "TVar", id: key, name: letterFromIndex(index) };
   });
-  const mapping: Record<number, tt.TVar> = Object.fromEntries(zip(keys, values));
+  const mapping: Record<number, tt.TVar> = Object.fromEntries(
+    zip(keys, values)
+  );
 
   const normType = (type: tt.Type): tt.Type => {
     switch (type.tag) {
@@ -183,7 +189,10 @@ const generalize = (env: Env, type: tt.Type): tt.Scheme => {
   return tt.scheme(ftv(type).subtract(ftv(env)).toArray(), type);
 };
 
-type InferResult<T extends tt.Type = tt.Type> = readonly [T, readonly tt.Constraint[]];
+type InferResult<T extends tt.Type = tt.Type> = readonly [
+  T,
+  readonly tt.Constraint[]
+];
 
 const infer = (expr: st.Expr, ctx: Context): InferResult => {
   // prettier-ignore
@@ -210,7 +219,14 @@ const inferApp = (expr: st.EApp, ctx: Context): InferResult => {
   const [t_args, cs_args] = inferMany(args, ctx);
   const tv = fresh(ctx);
   // This is almost the reverse of what we return from the "Lam" case
-  return [tv, [...cs_fn, ...cs_args, [t_fn, tb.tfun(t_args, tv, ctx, "App")]]];
+  return [
+    tv,
+    [
+      ...cs_fn,
+      ...cs_args,
+      { types: [t_fn, tb.tfun(t_args, tv, ctx, "App")], subtype: "Right" },
+    ],
+  ];
 };
 
 const inferAwait = (expr: st.EAwait, ctx: Context): InferResult => {
@@ -240,7 +256,10 @@ const inferFix = (expr: st.EFix, ctx: Context): InferResult => {
   const { expr: e } = expr;
   const [t, cs] = infer(e, ctx);
   const tv = fresh(ctx);
-  return [tv, [...cs, [tb.tfun([tv], tv, ctx, "Fix"), t]]];
+  return [
+    tv,
+    [...cs, { types: [tb.tfun([tv], tv, ctx, "Fix"), t], subtype: null }],
+  ];
 };
 
 const inferIf = (expr: st.EIf, ctx: Context): InferResult => {
@@ -250,7 +269,16 @@ const inferIf = (expr: st.EIf, ctx: Context): InferResult => {
   const [t3, cs3] = infer(el, ctx);
   // This is similar how we'll handle n-ary apply
   const bool = tb.tprim("boolean", ctx);
-  return [t2, [...cs1, ...cs2, ...cs3, [t1, bool], [t2, t3]]];
+  return [
+    t2,
+    [
+      ...cs1,
+      ...cs2,
+      ...cs3,
+      { types: [t1, bool], subtype: null },
+      { types: [t2, t3], subtype: null },
+    ],
+  ];
 };
 
 const inferLam = (expr: st.ELam, ctx: Context): InferResult => {
@@ -316,7 +344,7 @@ const inferPattern = (
     case "PLit": {
       const litType = tb.tlit(pattern.value, ctx);
       tt.freeze(litType); // prevents widening of inferred type
-      return [ctx, [[litType, type]]]; // doesn't affect binding
+      return [ctx, [{ types: [litType, type], subtype: null }]]; // doesn't affect binding
     }
     // NOTE: it only makes sense to infer PPrim patterns as part of pattern matching
     // since destructuring number | string to number isn't sound
@@ -334,7 +362,7 @@ const inferPattern = (
         );
       }
       tt.freeze(primType);
-      return [ctx, [[primType, type]]];
+      return [ctx, [{ types: [primType, type], subtype: null }]];
     }
     case "PRec": {
       if (type.tag !== "TRec") {
@@ -385,7 +413,10 @@ const inferOp = (expr: st.EOp, ctx: Context): InferResult => {
   const { op, left, right } = expr;
   const [ts, cs] = inferMany([left, right], ctx);
   const tv = fresh(ctx);
-  return [tv, [...cs, [tb.tfun(ts, tv, ctx), ops(op, ctx)]]];
+  return [
+    tv,
+    [...cs, { types: [tb.tfun(ts, tv, ctx), ops(op, ctx)], subtype: "Left" }],
+  ];
 };
 
 const inferRec = (expr: st.ERec, ctx: Context): InferResult<tt.TRec> => {
@@ -411,7 +442,7 @@ const inferVar = (expr: st.EVar, ctx: Context): InferResult => {
 const inferMem = (expr: st.EMem, ctx: Context): InferResult => {
   // TODO: handle nested property access, e.g. foo.bar.baz.
   const { object, property } = expr;
-  
+
   if (property.tag !== "Var") {
     throw new Error("property must be a variable when accessing a member");
   }
@@ -422,12 +453,14 @@ const inferMem = (expr: st.EMem, ctx: Context): InferResult => {
     const [type, cs] = inferRec(object, ctx);
     const tMem1 = tb.tmem(tobj, property.name, ctx);
     const tMem2 = tb.tmem(type, property.name, ctx);
-    const prop = type.properties.find(prop => property.name === prop.name);
+    const prop = type.properties.find((prop) => property.name === prop.name);
     if (!prop) {
-      throw new Error(`Record literal doesn't contain property '${property.name}'`);
+      throw new Error(
+        `Record literal doesn't contain property '${property.name}'`
+      );
     }
     // This is sufficient since infer() will unify `tobj` with `type`.
-    return [prop.type, [...cs, [tMem1, tMem2]]];
+    return [prop.type, [...cs, { types: [tMem1, tMem2], subtype: null }]];
   } else if (object.tag !== "Var") {
     throw new Error("object must be a variable when accessing a member");
   }
@@ -441,11 +474,13 @@ const inferMem = (expr: st.EMem, ctx: Context): InferResult => {
     const tMem1 = tb.tmem(tobj, property.name, ctx);
     const tMem2 = tb.tmem(type, property.name, ctx);
     // This is sufficient since inferTMem() will unify `tobj` with `type`.
-    return [tMem2, [[tMem1, tMem2]]];
+    return [tMem2, [{ types: [tMem1, tMem2], subtype: null }]];
   } else if (type.tag === "TRec") {
-    const prop = type.properties.find(prop => prop.name === property.name);
+    const prop = type.properties.find((prop) => prop.name === property.name);
     if (!prop) {
-      throw new Error(`${tt.print(type)} doesn't contain property ${property.name}`);
+      throw new Error(
+        `${tt.print(type)} doesn't contain property ${property.name}`
+      );
     }
     return [prop.type, []];
   } else if (type.tag !== "TCon") {
@@ -490,7 +525,9 @@ const inferMem = (expr: st.EMem, ctx: Context): InferResult => {
   }
 
   // Replaces all free variables with fresh ones
-  const subs2: tt.Subst = Map([...ftv(prop.type)].map((v) => [v.id, fresh(ctx)]));
+  const subs2: tt.Subst = Map(
+    [...ftv(prop.type)].map((v) => [v.id, fresh(ctx)])
+  );
   const resultType = apply(subs2, prop.type);
 
   return [resultType, []];

--- a/write-you-a-haskell/src/infer.ts
+++ b/write-you-a-haskell/src/infer.ts
@@ -224,7 +224,7 @@ const inferApp = (expr: st.EApp, ctx: Context): InferResult => {
     [
       ...cs_fn,
       ...cs_args,
-      { types: [t_fn, tb.tfun(t_args, tv, ctx, "App")], subtype: "Right" },
+      { types: [t_fn, tb.tfun(t_args, tv, ctx)], subtype: "Right" },
     ],
   ];
 };
@@ -256,10 +256,7 @@ const inferFix = (expr: st.EFix, ctx: Context): InferResult => {
   const { expr: e } = expr;
   const [t, cs] = infer(e, ctx);
   const tv = fresh(ctx);
-  return [
-    tv,
-    [...cs, { types: [tb.tfun([tv], tv, ctx, "Fix"), t], subtype: null }],
-  ];
+  return [tv, [...cs, { types: [tb.tfun([tv], tv, ctx), t], subtype: null }]];
 };
 
 const inferIf = (expr: st.EIf, ctx: Context): InferResult => {
@@ -305,7 +302,7 @@ const inferLam = (expr: st.ELam, ctx: Context): InferResult => {
       ? type
       : freshTCon(ctx, "Promise", [type]);
 
-  return [tb.tfun(tvs, ret, ctx, "Lam"), cs];
+  return [tb.tfun(tvs, ret, ctx), cs];
 };
 
 const inferLet = (expr: st.ELet, ctx: Context): InferResult => {

--- a/write-you-a-haskell/src/type-builders.ts
+++ b/write-you-a-haskell/src/type-builders.ts
@@ -24,14 +24,12 @@ export const tcon = (
 export const tfun = (
   args: readonly t.Type[],
   ret: t.Type,
-  ctx: Context,
-  src?: "App" | "Fix" | "Lam"
+  ctx: Context
 ): t.TFun => ({
   tag: "TFun",
   id: newId(ctx),
   args,
   ret,
-  src,
 });
 
 export const tunion = (types: readonly t.Type[], ctx: Context): t.TUnion => ({
@@ -58,7 +56,11 @@ export const tprop = (name: string, type: t.Type): t.TProp => ({
   type,
 });
 
-export const tmem = (object: t.Type, property: string, ctx: Context): t.TMem => ({
+export const tmem = (
+  object: t.Type,
+  property: string,
+  ctx: Context
+): t.TMem => ({
   tag: "TMem",
   id: newId(ctx),
   object,

--- a/write-you-a-haskell/src/type-types.ts
+++ b/write-you-a-haskell/src/type-types.ts
@@ -146,7 +146,11 @@ export const isTLit = (t: Type): t is TLit => t.tag === "TLit";
 export const isTMem = (t: Type): t is TMem => t.tag === "TMem";
 export const isScheme = (t: any): t is Scheme => t.tag === "Forall";
 
-export type Constraint = readonly [Type, Type];
+export type Constraint<T extends Type = Type> = {
+  types: readonly [T, T],
+  subtype: "Left" | "Right" | null,
+};
+
 export type Unifier = readonly [Subst, readonly Constraint[]];
 
 export type Subst = Map<number, Type>;

--- a/write-you-a-haskell/src/type-types.ts
+++ b/write-you-a-haskell/src/type-types.ts
@@ -8,12 +8,11 @@ function assertUnreachable(x: never): never {
 
 type TCommon = { frozen?: boolean; id: number };
 
-export type Src = "App" | "Fix" | "Lam";
 export type PrimName = "boolean" | "number" | "string" | "null" | "undefined";
 
 export type TVar = TCommon & { tag: "TVar"; name: string };
 export type TCon = TCommon & { tag: "TCon"; name: string; params: readonly Type[] }; // prettier-ignore
-export type TFun = TCommon & { tag: "TFun"; args: readonly Type[]; ret: Type; src?: Src }; // prettier-ignore
+export type TFun = TCommon & { tag: "TFun"; args: readonly Type[]; ret: Type }; // prettier-ignore
 export type TUnion = TCommon & { tag: "TUnion"; types: readonly Type[] };
 export type TRec = TCommon & { tag: "TRec"; properties: readonly TProp[] };
 export type TMem = TCommon & { tag: "TMem"; object: Type; property: string };

--- a/write-you-a-haskell/src/type-types.ts
+++ b/write-you-a-haskell/src/type-types.ts
@@ -147,7 +147,7 @@ export const isScheme = (t: any): t is Scheme => t.tag === "Forall";
 
 export type Constraint<T extends Type = Type> = {
   types: readonly [T, T],
-  subtype: "Left" | "Right" | null,
+  subtype: boolean,
 };
 
 export type Unifier = readonly [Subst, readonly Constraint[]];

--- a/write-you-a-haskell/src/util.ts
+++ b/write-you-a-haskell/src/util.ts
@@ -208,7 +208,7 @@ export function zip<A, B>(
 export function zipTypes(
   ts1: readonly Type[],
   ts2: readonly Type[],
-  subtype: "Left" | "Right" | null,
+  subtype: boolean,
   funcArgs?: boolean
 ): readonly Constraint[] {
   const length = Math.min(ts1.length, ts2.length);
@@ -216,10 +216,14 @@ export function zipTypes(
   for (let i = 0; i < length; i++) {
     // If the types that we're zipping are args passed to a function
     // then we need to set the `subtype` direction correctly.
-    if (funcArgs && ts1[i].tag === "TFun") {
-      result.push({ types: [ts1[i], ts2[i]], subtype: "Left" });
-    } else if (funcArgs && ts2[i].tag === "TFun") {
-      result.push({ types: [ts1[i], ts2[i]], subtype: "Right" });
+    if (funcArgs && ts2[i].tag === "TFun") {
+      // Reverses the order of the types so that the TFun is first.
+      // This can happen when a function is passed as a callback.
+      // The callback passed should be a subtype of the expected param
+      // type.
+      result.push({ types: [ts2[i], ts1[i]], subtype: true });
+    } else if (funcArgs && ts1[i].tag === "TFun") {
+      result.push({ types: [ts1[i], ts2[i]], subtype: true });
     } else {
       result.push({ types: [ts1[i], ts2[i]], subtype });
     }

--- a/write-you-a-haskell/src/util.ts
+++ b/write-you-a-haskell/src/util.ts
@@ -1,7 +1,15 @@
 import { Map, OrderedSet } from "immutable";
 
 import { Env } from "./context";
-import { Type, TVar, Subst, Constraint, Scheme, isTLit, isTMem } from "./type-types";
+import {
+  Type,
+  TVar,
+  Subst,
+  Constraint,
+  Scheme,
+  isTLit,
+  isTMem,
+} from "./type-types";
 import {
   isTCon,
   isTVar,
@@ -19,7 +27,10 @@ export function apply(s: Subst, scheme: Scheme): Scheme;
 export function apply(s: Subst, types: readonly Type[]): readonly Type[];
 export function apply(s: Subst, schemes: readonly Scheme[]): readonly Scheme[];
 export function apply(s: Subst, constraint: Constraint): Constraint; // special case of Type[]
-export function apply(s: Subst, constraint: readonly Constraint[]): readonly Constraint[]; 
+export function apply(
+  s: Subst,
+  constraint: readonly Constraint[]
+): readonly Constraint[];
 export function apply(
   s: Subst,
   constraint: readonly Constraint[]
@@ -86,7 +97,7 @@ export function apply(s: Subst, a: any): any {
         ...a,
         object: apply(s, a.object),
       }
-    )
+    );
   }
 
   // instance Substitutable Scheme
@@ -118,7 +129,7 @@ export function apply(s: Subst, a: any): any {
     return {
       ...a,
       types: apply(s, a.types),
-    }
+    };
   }
 
   throw new Error(`apply doesn't handle ${a}`);
@@ -182,7 +193,10 @@ export function ftv(a: any): any {
   throw new Error(`ftv doesn't handle ${a}`);
 }
 
-export function zip<A, B>(as: readonly A[], bs: readonly B[]): readonly [A, B][] {
+export function zip<A, B>(
+  as: readonly A[],
+  bs: readonly B[]
+): readonly [A, B][] {
   const length = Math.min(as.length, bs.length);
   const result: [A, B][] = [];
   for (let i = 0; i < length; i++) {
@@ -191,11 +205,24 @@ export function zip<A, B>(as: readonly A[], bs: readonly B[]): readonly [A, B][]
   return result;
 }
 
-export function zipTypes(ts1: readonly Type[], ts2: readonly Type[], subtype: "Left" | "Right" | null): readonly Constraint[] {
+export function zipTypes(
+  ts1: readonly Type[],
+  ts2: readonly Type[],
+  subtype: "Left" | "Right" | null,
+  funcArgs?: boolean
+): readonly Constraint[] {
   const length = Math.min(ts1.length, ts2.length);
   const result: Constraint[] = [];
   for (let i = 0; i < length; i++) {
-    result.push({types: [ts1[i], ts2[i]], subtype});
+    // If the types that we're zipping are args passed to a function
+    // then we need to set the `subtype` direction correctly.
+    if (funcArgs && ts1[i].tag === "TFun") {
+      result.push({ types: [ts1[i], ts2[i]], subtype: "Left" });
+    } else if (funcArgs && ts2[i].tag === "TFun") {
+      result.push({ types: [ts1[i], ts2[i]], subtype: "Right" });
+    } else {
+      result.push({ types: [ts1[i], ts2[i]], subtype });
+    }
   }
   return result;
 }

--- a/write-you-a-haskell/src/util.ts
+++ b/write-you-a-haskell/src/util.ts
@@ -114,6 +114,13 @@ export function apply(s: Subst, a: any): any {
     return (a as Env).map((sc) => apply(s, sc));
   }
 
+  if (Array.isArray(a.types)) {
+    return {
+      ...a,
+      types: apply(s, a.types),
+    }
+  }
+
   throw new Error(`apply doesn't handle ${a}`);
 }
 
@@ -122,6 +129,7 @@ export function ftv(scheme: Scheme): OrderedSet<TVar>;
 export function ftv(types: readonly Type[]): OrderedSet<TVar>;
 export function ftv(schemes: readonly Scheme[]): OrderedSet<TVar>;
 export function ftv(constraint: Constraint): OrderedSet<TVar>; // special case of Type[]
+export function ftv(constraint: readonly Constraint[]): OrderedSet<TVar>; // special case of Type[]
 export function ftv(env: Env): OrderedSet<TVar>;
 export function ftv(a: any): any {
   // instance Substitutable Type
@@ -174,11 +182,20 @@ export function ftv(a: any): any {
   throw new Error(`ftv doesn't handle ${a}`);
 }
 
-export function zip<A, B>(as: readonly A[], bs: readonly B[]): [A, B][] {
+export function zip<A, B>(as: readonly A[], bs: readonly B[]): readonly [A, B][] {
   const length = Math.min(as.length, bs.length);
   const result: [A, B][] = [];
   for (let i = 0; i < length; i++) {
     result.push([as[i], bs[i]]);
+  }
+  return result;
+}
+
+export function zipTypes(ts1: readonly Type[], ts2: readonly Type[], subtype: "Left" | "Right" | null): readonly Constraint[] {
+  const length = Math.min(ts1.length, ts2.length);
+  const result: Constraint[] = [];
+  for (let i = 0; i < length; i++) {
+    result.push({types: [ts1[i], ts2[i]], subtype});
   }
   return result;
 }

--- a/write-you-a-haskell/src/util.ts
+++ b/write-you-a-haskell/src/util.ts
@@ -19,6 +19,7 @@ export function apply(s: Subst, scheme: Scheme): Scheme;
 export function apply(s: Subst, types: readonly Type[]): readonly Type[];
 export function apply(s: Subst, schemes: readonly Scheme[]): readonly Scheme[];
 export function apply(s: Subst, constraint: Constraint): Constraint; // special case of Type[]
+export function apply(s: Subst, constraint: readonly Constraint[]): readonly Constraint[]; 
 export function apply(
   s: Subst,
   constraint: readonly Constraint[]


### PR DESCRIPTION
Relying on setting `.src` to "App" or "Lam" was insufficient to correctly enforce sub-typing because subtype constraints could occur on deeply nested types far away from a function call.  This updates the `Constraint` type to be an object that contains the `.types` being constrained as well as the direction ("Left" or "Right") of the `.subtype` constraint if there is on.  This allow any subtype constraints to be fully propagated throughout the system.

TODO:
- [x] drop the `.src` property on `TFun` nodes