### PR TITLE
Add support for varargs (rest params)

### DIFF
--- a/src/infer/__tests__/array.test.ts
+++ b/src/infer/__tests__/array.test.ts
@@ -45,7 +45,7 @@ describe("Array", () => {
     eng.defType("strArray", eng.tgen("Array", [eng.tprim("string")]));
 
     const expr = sb.app(sb.mem(sb.ident("strArray"), sb.ident("map")), [
-      sb.lam(["elem"], sb.num(5)),
+      sb.lam([sb.ident("elem")], sb.num(5)),
     ]);
     const result = eng.inferExpr(expr);
 
@@ -58,7 +58,10 @@ describe("Array", () => {
     eng.defType("strArray", eng.tgen("Array", [eng.tprim("string")]));
 
     const expr = sb.app(sb.mem(sb.ident("strArray"), sb.ident("map")), [
-      sb.lam(["elem", "index", "array"], sb.ident("index")),
+      sb.lam(
+        [sb.ident("elem"), sb.ident("index"), sb.ident("array")],
+        sb.ident("index")
+      ),
     ]);
     const result = eng.inferExpr(expr);
 
@@ -71,7 +74,10 @@ describe("Array", () => {
     eng.defType("strArray", eng.tgen("Array", [eng.tprim("string")]));
 
     const expr = sb.app(sb.mem(sb.ident("strArray"), sb.ident("map")), [
-      sb.lam(["elem", "index", "array"], sb.ident("array")),
+      sb.lam(
+        [sb.ident("elem"), sb.ident("index"), sb.ident("array")],
+        sb.ident("array")
+      ),
     ]);
     const result = eng.inferExpr(expr);
 
@@ -85,7 +91,7 @@ describe("Array", () => {
 
     const expr = sb.app(sb.mem(sb.ident("strArray"), sb.ident("map")), [
       sb.lam(
-        ["elem", "index", "array"],
+        [sb.ident("elem"), sb.ident("index"), sb.ident("array")],
         sb.mem(sb.ident("array"), sb.ident("length"))
       ),
     ]);

--- a/src/infer/__tests__/async-await.test.ts
+++ b/src/infer/__tests__/async-await.test.ts
@@ -15,10 +15,7 @@ describe("Async/Await", () => {
 
   test("return value is not rewrapped if already a promise", () => {
     const eng = new Engine();
-    const retVal = scheme(
-      [],
-      eng.tgen("Promise", [eng.tprim("number")]),
-    );
+    const retVal = scheme([], eng.tgen("Promise", [eng.tprim("number")]));
     eng.defScheme("retVal", retVal);
 
     const expr: Expr = sb.lam([], sb.ident("retVal"), true);
@@ -29,15 +26,16 @@ describe("Async/Await", () => {
 
   test("awaiting a promise will unwrap it", () => {
     const eng = new Engine();
-    const retVal = scheme(
-      [],
-      eng.tgen("Promise", [eng.tprim("number")]),
-    );
+    const retVal = scheme([], eng.tgen("Promise", [eng.tprim("number")]));
     eng.defScheme("retVal", retVal);
 
     // Passing an awaited Promise<number> to add() verifies that we're
     // unwrapping promises.
-    const expr: Expr = sb.lam([], sb.add(sb._await(sb.ident("retVal")), sb.num(5)), true);
+    const expr: Expr = sb.lam(
+      [],
+      sb.add(sb._await(sb.ident("retVal")), sb.num(5)),
+      true
+    );
     const result = eng.inferExpr(expr);
 
     expect(print(result)).toEqual("() => Promise<number>");
@@ -47,7 +45,11 @@ describe("Async/Await", () => {
     const eng = new Engine();
     // Passing an awaited Promise<number> to add() verifies that we're
     // unwrapping promises.
-    const expr: Expr = sb.lam([], sb.add(sb._await(sb.num(5)), sb.num(10)), true);
+    const expr: Expr = sb.lam(
+      [],
+      sb.add(sb._await(sb.num(5)), sb.num(10)),
+      true
+    );
 
     const result = eng.inferExpr(expr);
 
@@ -56,7 +58,7 @@ describe("Async/Await", () => {
 
   test("inferring an async function that returns a polymorphic promise", () => {
     const eng = new Engine();
-    const expr: Expr = sb.lam(["x"], sb.app(sb.ident("x"), []), true);
+    const expr: Expr = sb.lam([sb.ident("x")], sb.app(sb.ident("x"), []), true);
 
     const result = eng.inferExpr(expr);
 
@@ -78,7 +80,10 @@ describe("Async/Await", () => {
       [],
       sb._let(
         "add",
-        sb.lam(["a", "b"], sb.add(sb._await(sb.ident("a")), sb.ident("b"))),
+        sb.lam(
+          [sb.ident("a"), sb.ident("b")],
+          sb.add(sb._await(sb.ident("a")), sb.ident("b"))
+        ),
         sb.app(sb.ident("add"), [sb.num(5), sb.num(10)])
       ),
       true // Even though the outer lambda is async, the inner one isn't
@@ -95,7 +100,11 @@ describe("Async/Await", () => {
       [],
       sb._let(
         "add",
-        sb.lam(["a", "b"], sb.add(sb._await(sb.ident("a")), sb.ident("b")), true),
+        sb.lam(
+          [sb.ident("a"), sb.ident("b")],
+          sb.add(sb._await(sb.ident("a")), sb.ident("b")),
+          true
+        ),
         sb.app(sb.ident("add"), [sb.num(5), sb.num(10)])
       ),
       false

--- a/src/infer/__tests__/destructuring.test.ts
+++ b/src/infer/__tests__/destructuring.test.ts
@@ -227,7 +227,7 @@ describe("destructuring", () => {
 
   test("parametrized record", () => {
     const eng = new Engine();
-    const expr: Expr = sb.lam(["x"], {
+    const expr: Expr = sb.lam([sb.ident("x")], {
       tag: "ELet",
       pattern: sb.prec([sb.pprop("x", sb.pvar("a"))]),
       value: sb.rec([sb.prop("x", sb.ident("x"))]),
@@ -241,7 +241,7 @@ describe("destructuring", () => {
 
   test("parametrized tuple", () => {
     const eng = new Engine();
-    const expr: Expr = sb.lam(["x"], {
+    const expr: Expr = sb.lam([sb.ident("x")], {
       tag: "ELet",
       pattern: sb.ptuple([sb.pvar("a")]),
       value: sb.tuple([sb.ident("x")]),

--- a/src/infer/__tests__/function.test.ts
+++ b/src/infer/__tests__/function.test.ts
@@ -6,7 +6,10 @@ import { Engine } from "../engine";
 
 type Binding = [string, Expr];
 
-const _const: Binding = ["const", sb.lam(["x", "y"], sb.ident("x"))];
+const _const: Binding = [
+  "const",
+  sb.lam([sb.ident("x"), sb.ident("y")], sb.ident("x")),
+];
 
 describe("Functions", () => {
   test("let rec fib = (n) => ...", () => {
@@ -19,9 +22,9 @@ describe("Functions", () => {
       "fib",
       sb.fix(
         sb.lam(
-          ["fib"],
+          [sb.ident("fib")],
           sb.lam(
-            ["n"],
+            [sb.ident("n")],
             sb._if(
               sb.eql(sb.ident("n"), sb.num(0)),
               // then
@@ -64,10 +67,13 @@ describe("Functions", () => {
     const y: Binding = [
       "y",
       sb.lam(
-        ["y"],
+        [sb.ident("y")],
         sb._let(
           "f",
-          sb.lam(["x"], sb._if(sb.ident("x"), sb.bool(true), sb.bool(false))),
+          sb.lam(
+            [sb.ident("x")],
+            sb._if(sb.ident("x"), sb.bool(true), sb.bool(false))
+          ),
           sb.app(sb.ident("const"), [
             sb.app(sb.ident("f"), [sb.ident("y")]),
             sb.ident("y"),
@@ -76,12 +82,12 @@ describe("Functions", () => {
       ),
     ];
     // let id x = x;
-    const id: Binding = ["id", sb.lam(["x"], sb.ident("x"))];
+    const id: Binding = ["id", sb.lam([sb.ident("x")], sb.ident("x"))];
     // let foo x = let y = id x in y + 1;
     const foo: Binding = [
       "foo",
       sb.lam(
-        ["x"],
+        [sb.ident("x")],
         sb._let(
           "y",
           sb.app(sb.ident("id"), [sb.ident("x")]),
@@ -116,11 +122,11 @@ describe("Functions", () => {
     const compose: Binding = [
       "compose",
       sb.lam(
-        ["f"],
+        [sb.ident("f")],
         sb.lam(
-          ["g"],
+          [sb.ident("g")],
           sb.lam(
-            ["x"],
+            [sb.ident("x")],
             sb.app(sb.ident("g"), [sb.app(sb.ident("f"), [sb.ident("x")])])
           )
         )
@@ -139,9 +145,9 @@ describe("Functions", () => {
     const on: Binding = [
       "on",
       sb.lam(
-        ["g", "f"],
+        [sb.ident("g"), sb.ident("f")],
         sb.lam(
-          ["x", "y"],
+          [sb.ident("x"), sb.ident("y")],
           sb.app(sb.ident("g"), [
             sb.app(sb.ident("f"), [sb.ident("x")]),
             sb.app(sb.ident("f"), [sb.ident("y")]),
@@ -163,7 +169,7 @@ describe("Functions", () => {
     const ap: Binding = [
       "ap",
       sb.lam(
-        ["f", "x"],
+        [sb.ident("f"), sb.ident("x")],
         sb.app(sb.ident("f"), [sb.app(sb.ident("f"), [sb.ident("x")])])
       ),
     ];
@@ -180,9 +186,9 @@ describe("Functions", () => {
       // let rec until p f x =
       sb.fix(
         sb.lam(
-          ["until"],
+          [sb.ident("until")],
           sb.lam(
-            ["p", "f", "x"],
+            [sb.ident("p"), sb.ident("f"), sb.ident("x")],
             sb._if(
               //   if (p x)
               sb.app(sb.ident("p"), [sb.ident("x")]),
@@ -220,7 +226,10 @@ describe("partial applicaiton", () => {
     const eng = new Engine();
     const _add: Binding = [
       "add",
-      sb.lam(["a", "b"], sb.add(sb.ident("a"), sb.ident("b"))),
+      sb.lam(
+        [sb.ident("a"), sb.ident("b")],
+        sb.add(sb.ident("a"), sb.ident("b"))
+      ),
     ];
     const add5: Binding = ["add5", sb.app(sb.ident("add"), [sb.num(5)])];
 
@@ -234,7 +243,10 @@ describe("partial applicaiton", () => {
     const eng = new Engine();
     const _add: Binding = [
       "add",
-      sb.lam(["a", "b"], sb.add(sb.ident("a"), sb.ident("b"))),
+      sb.lam(
+        [sb.ident("a"), sb.ident("b")],
+        sb.add(sb.ident("a"), sb.ident("b"))
+      ),
     ];
     const sum: Binding = [
       "sum",
@@ -251,9 +263,13 @@ describe("partial applicaiton", () => {
     const eng = new Engine();
     const add5: Binding = [
       "add5",
-      sb.app(sb.lam(["a", "b"], sb.add(sb.ident("a"), sb.ident("b"))), [
-        sb.num(5),
-      ]),
+      sb.app(
+        sb.lam(
+          [sb.ident("a"), sb.ident("b")],
+          sb.add(sb.ident("a"), sb.ident("b"))
+        ),
+        [sb.num(5)]
+      ),
     ];
 
     const result = eng.inferExpr(add5[1]);
@@ -267,7 +283,10 @@ describe("function subtyping", () => {
     const eng = new Engine();
     const _add: Binding = [
       "add",
-      sb.lam(["a", "b"], sb.add(sb.ident("a"), sb.ident("b"))),
+      sb.lam(
+        [sb.ident("a"), sb.ident("b")],
+        sb.add(sb.ident("a"), sb.ident("b"))
+      ),
     ];
     const sum: Binding = [
       "sum",
@@ -305,7 +324,7 @@ describe("function subtyping", () => {
 
     const call = sb.app(sb.ident("map"), [
       sb.ident("array"),
-      sb.lam(["x"], sb.eql(sb.ident("x"), sb.num(0))),
+      sb.lam([sb.ident("x")], sb.eql(sb.ident("x"), sb.num(0))),
     ]);
 
     const result = eng.inferExpr(call);
@@ -325,7 +344,7 @@ describe("function subtyping", () => {
 
     // TODO: allow `(elem) => 5` to be passed as the callback
     const expr = sb.app(sb.mem(sb.ident("strArray"), sb.ident("map")), [
-      sb.lam(["elem"], sb.num(5)),
+      sb.lam([sb.ident("elem")], sb.num(5)),
     ]);
     const result = eng.inferExpr(expr);
 
@@ -356,17 +375,159 @@ describe("function subtyping", () => {
 
     const _add: Binding = [
       "add",
-      sb.lam(["a", "b"], sb.add(sb.ident("a"), sb.ident("b"))),
+      sb.lam(
+        [sb.ident("a"), sb.ident("b")],
+        sb.add(sb.ident("a"), sb.ident("b"))
+      ),
     ];
     eng.inferDecl(_add[0], _add[1]);
 
     const call = sb.app(sb.ident("map"), [
       sb.ident("array"),
-      sb.lam(["x"], sb.app(sb.ident("add"), [sb.ident("x")])),
+      sb.lam([sb.ident("x")], sb.app(sb.ident("add"), [sb.ident("x")])),
     ]);
 
     const result = eng.inferExpr(call);
 
     expect(print(result)).toEqual("Array<(number) => number>");
+  });
+
+  describe("varargs", () => {
+    test("basic inference", () => {
+      const eng = new Engine();
+      const foo = sb.lam([sb.rest("rest")], sb.num(5));
+
+      const result = eng.inferExpr(foo);
+
+      expect(print(result)).toEqual("<a>(...Array<a>) => 5");
+    });
+
+    test("multiple rest params is not allowed", () => {
+      const eng = new Engine();
+      const foo = sb.lam([sb.rest("rest"), sb.rest("rest")], sb.num(5));
+
+      expect(() => eng.inferExpr(foo)).toThrowErrorMatchingInlineSnapshot(
+        `"Rest param must come last."`
+      );
+    });
+
+    test("rest param must come last", () => {
+      const eng = new Engine();
+      const foo = sb.lam([sb.rest("rest"), sb.ident("x")], sb.num(5));
+
+      expect(() => eng.inferExpr(foo)).toThrowErrorMatchingInlineSnapshot(
+        `"Rest param must come last."`
+      );
+    });
+
+    test("varargs with numbers only", () => {
+      const eng = new Engine();
+      const foo = sb._let(
+        "foo",
+        sb.lam([sb.rest("rest")], sb.ident("rest")),
+        sb.app(sb.ident("foo"), [sb.num(5), sb.num(10)])
+      );
+
+      const result = eng.inferExpr(foo);
+
+      expect(print(result)).toEqual("Array<10 | 5>");
+    });
+
+    test("varargs with a mix of types", () => {
+      const eng = new Engine();
+      const foo = sb._let(
+        "foo",
+        sb.lam([sb.rest("rest")], sb.ident("rest")),
+        sb.app(sb.ident("foo"), [sb.num(5), sb.bool(true)])
+      );
+
+      const result = eng.inferExpr(foo);
+
+      expect(print(result)).toEqual("Array<true | 5>");
+    });
+
+    test("varargs with no args", () => {
+      const eng = new Engine();
+      const foo = sb._let(
+        "foo",
+        sb.lam([sb.rest("rest")], sb.ident("rest")),
+        sb.app(sb.ident("foo"), [])
+      );
+
+      const result = eng.inferExpr(foo);
+
+      expect(print(result)).toEqual("<a>Array<a>");
+    });
+
+    test("varargs with regular args", () => {
+      const eng = new Engine();
+      const foo = sb._let(
+        "foo",
+        sb.lam([sb.ident("x"), sb.rest("rest")], sb.ident("rest")),
+        sb.app(sb.ident("foo"), [sb.str("hello"), sb.num(5), sb.num(10)])
+      );
+
+      const result = eng.inferExpr(foo);
+
+      expect(print(result)).toEqual("Array<10 | 5>");
+    });
+
+    test("varargs with regular args (but no varargs passed)", () => {
+      const eng = new Engine();
+      const foo = sb._let(
+        "foo",
+        sb.lam([sb.ident("x"), sb.rest("rest")], sb.ident("rest")),
+        sb.app(sb.ident("foo"), [sb.str("hello")])
+      );
+
+      const result = eng.inferExpr(foo);
+
+      expect(print(result)).toEqual("<a>Array<a>");
+    });
+
+    test("regular args with varargs", () => {
+      const eng = new Engine();
+      const foo = sb._let(
+        "foo",
+        sb.lam([sb.ident("x"), sb.rest("rest")], sb.ident("x")),
+        sb.app(sb.ident("foo"), [sb.str("hello"), sb.num(5), sb.num(10)])
+      );
+
+      const result = eng.inferExpr(foo);
+
+      expect(print(result)).toEqual('"hello"');
+    });
+
+    test("partially application of varargs", () => {
+      const eng = new Engine();
+      const foo = sb._let(
+        "foo",
+        sb.lam(
+          [sb.ident("x"), sb.ident("y"), sb.rest("rest")],
+          sb.ident("rest")
+        ),
+        sb.app(sb.ident("foo"), [sb.str("hello")])
+      );
+
+      const result = eng.inferExpr(foo);
+
+      expect(print(result)).toEqual("<a>(Array<a>) => Array<a>");
+    });
+
+    test("variadic callbacks", () => {
+      const eng = new Engine();
+      eng.inferDecl(
+        "foo",
+        sb.lam([sb.ident("x"), sb.rest("rest")], sb.ident("x"))
+      );
+      eng.inferDecl(_const[0], _const[1]);
+      const bar = sb.app(sb.ident("const"), [sb.ident("foo")]);
+
+      const result = eng.inferExpr(bar);
+
+      expect(print(result)).toMatchInlineSnapshot(
+        `"<a, b, c>(a) => (b, ...Array<c>) => b"`
+      );
+    });
   });
 });

--- a/src/infer/__tests__/function.test.ts
+++ b/src/infer/__tests__/function.test.ts
@@ -529,5 +529,44 @@ describe("function subtyping", () => {
         `"<a, b, c>(a) => (b, ...Array<c>) => b"`
       );
     });
+
+    test("calling a pre-defined func with variadic callback", () => {
+      const eng = new Engine();
+      eng.defType(
+        "foo",
+        eng.tfun(
+          [eng.tgen("Array", [eng.tprim("number")])],
+          eng.tprim("number"),
+          true
+        )
+      );
+
+      const result = eng.inferExpr(
+        sb.lam([sb.ident("x")], sb.app(sb.ident("foo"), [sb.ident("x")]))
+      );
+
+      expect(print(result)).toMatchInlineSnapshot(`"(number) => number"`);
+    });
+
+    test("passing a variadic function as an arg", () => {
+      const eng = new Engine();
+      eng.defType(
+        "foo",
+        eng.tfun(
+          [eng.tgen("Array", [eng.tprim("number")])],
+          eng.tprim("number"),
+          true
+        )
+      );
+      eng.inferDecl(_const[0], _const[1]);
+
+      const result = eng.inferExpr(
+        sb.app(sb.ident("const"), [sb.ident("foo"), sb.str("hello")])
+      );
+
+      expect(print(result)).toMatchInlineSnapshot(
+        `"(...Array<number>) => number"`
+      );
+    });
   });
 });

--- a/src/infer/__tests__/infer.test.ts
+++ b/src/infer/__tests__/infer.test.ts
@@ -5,17 +5,20 @@ import { Engine } from "../engine";
 
 type Binding = [string, Expr];
 
-const I: Binding = ["I", sb.lam(["x"], sb.ident("x"))];
-const K: Binding = ["K", sb.lam(["x"], sb.lam(["y"], sb.ident("x")))];
+const I: Binding = ["I", sb.lam([sb.ident("x")], sb.ident("x"))];
+const K: Binding = [
+  "K",
+  sb.lam([sb.ident("x")], sb.lam([sb.ident("y")], sb.ident("x"))),
+];
 // let S = (f) => (g) => (x) => f(x)(g(x))
 const S: Binding = [
   "S",
   sb.lam(
-    ["f"],
+    [sb.ident("f")],
     sb.lam(
-      ["g"],
+      [sb.ident("g")],
       sb.lam(
-        ["x"],
+        [sb.ident("x")],
         sb.app(sb.app(sb.ident("f"), [sb.ident("x")]), [
           sb.app(sb.ident("g"), [sb.ident("x")]),
         ])
@@ -67,7 +70,7 @@ describe("inferExpr", () => {
       const eng = new Engine();
       const Mu: Binding = [
         "Mu",
-        sb.lam(["f"], sb.app(sb.ident("f"), [sb.fix(sb.ident("f"))])),
+        sb.lam([sb.ident("f")], sb.app(sb.ident("f"), [sb.fix(sb.ident("f"))])),
       ];
 
       const result = eng.inferExpr(Mu[1]);
@@ -81,7 +84,7 @@ describe("inferExpr", () => {
       const eng = new Engine();
       const nsucc: Binding = [
         "nsucc",
-        sb.lam(["x"], sb.add(sb.ident("x"), sb.num(1))),
+        sb.lam([sb.ident("x")], sb.add(sb.ident("x"), sb.num(1))),
       ];
 
       const result = eng.inferExpr(nsucc[1]);
@@ -93,7 +96,7 @@ describe("inferExpr", () => {
       const eng = new Engine();
       const nsucc: Binding = [
         "nsucc",
-        sb.lam(["x"], sb.add(sb.ident("x"), sb.num(1))),
+        sb.lam([sb.ident("x")], sb.add(sb.ident("x"), sb.num(1))),
       ];
 
       const result = eng.inferExpr(nsucc[1]);
@@ -120,7 +123,9 @@ describe("inferExpr", () => {
       const eng = new Engine();
       const self: Binding = [
         "self",
-        sb.app(sb.lam(["x"], sb.ident("x")), [sb.lam(["x"], sb.ident("x"))]),
+        sb.app(sb.lam([sb.ident("x")], sb.ident("x")), [
+          sb.lam([sb.ident("x")], sb.ident("x")),
+        ]),
       ];
 
       const result = eng.inferExpr(self[1]);
@@ -133,8 +138,8 @@ describe("inferExpr", () => {
       const innerlet: Binding = [
         "innerlet",
         sb.lam(
-          ["x"],
-          sb._let("y", sb.lam(["z"], sb.ident("z")), sb.ident("y"))
+          [sb.ident("x")],
+          sb._let("y", sb.lam([sb.ident("z")], sb.ident("z")), sb.ident("y"))
         ),
       ];
 
@@ -154,7 +159,10 @@ describe("inferExpr", () => {
         "f",
         sb._let(
           "add",
-          sb.lam(["a", "b"], sb.add(sb.ident("a"), sb.ident("b"))),
+          sb.lam(
+            [sb.ident("a"), sb.ident("b")],
+            sb.add(sb.ident("a"), sb.ident("b"))
+          ),
           sb.ident("add")
         ),
       ];
@@ -207,7 +215,7 @@ describe("inferExpr", () => {
       eng.defScheme("extract", extractScheme);
 
       const addFoos = sb.lam(
-        ["x", "y"],
+        [sb.ident("x"), sb.ident("y")],
         sb.add(
           sb.app(sb.ident("extract"), [sb.ident("x")]),
           sb.app(sb.ident("extract"), [sb.ident("y")])
@@ -259,7 +267,10 @@ describe("inferExpr", () => {
       const eng = new Engine();
       const _add: Binding = [
         "add",
-        sb.lam(["a", "b"], sb.add(sb.ident("a"), sb.ident("b"))),
+        sb.lam(
+          [sb.ident("a"), sb.ident("b")],
+          sb.add(sb.ident("a"), sb.ident("b"))
+        ),
       ];
       const expr = sb.app(sb.ident("add"), [sb.num(5), sb.bool(true)]);
 
@@ -276,7 +287,7 @@ describe("inferExpr", () => {
       const eng = new Engine();
       const omega: Binding = [
         "omega",
-        sb.lam(["x"], sb.app(sb.ident("x"), [sb.ident("x")])),
+        sb.lam([sb.ident("x")], sb.app(sb.ident("x"), [sb.ident("x")])),
       ];
 
       expect(() => eng.inferExpr(omega[1])).toThrowErrorMatchingInlineSnapshot(

--- a/src/infer/__tests__/union.test.ts
+++ b/src/infer/__tests__/union.test.ts
@@ -42,7 +42,7 @@ describe("Union types and type widening", () => {
   test("infer lambda with union return type", () => {
     const eng = new Engine();
     const expr: Expr = sb.lam(
-      ["x", "y"],
+      [sb.ident("x"), sb.ident("y")],
       sb._if(
         sb.ident("x"),
         sb.app(sb.ident("y"), [sb.num(5)]),
@@ -72,7 +72,7 @@ describe("Union types and type widening", () => {
     eng.ctx.env = eng.ctx.env.set("bar", bar);
 
     const expr: Expr = sb.lam(
-      ["x"],
+      [sb.ident("x")],
       sb._if(sb.ident("x"), sb.ident("foo"), sb.ident("bar"))
     );
 
@@ -95,7 +95,7 @@ describe("Union types and type widening", () => {
     expect(print(union)).toEqual("number | boolean");
 
     const expr: Expr = sb.lam(
-      ["x", "y"],
+      [sb.ident("x"), sb.ident("y")],
       sb._if(
         sb.ident("x"),
         sb.app(sb.ident("y"), [sb.ident("union")]), // number | boolean
@@ -113,7 +113,7 @@ describe("Union types and type widening", () => {
   test("widen inferred union type", () => {
     const eng = new Engine();
     const expr: Expr = sb.lam(
-      ["x"],
+      [sb.ident("x")],
       sb._let(
         "a",
         sb.app(sb.ident("x"), [sb.num(5)]),
@@ -136,7 +136,7 @@ describe("Union types and type widening", () => {
     const eng = new Engine();
     const _add: Binding = [
       "add",
-      sb.lam(["a", "b"], sb.add(sb.ident("a"), sb.ident("b"))),
+      sb.lam([sb.ident("a"), sb.ident("b")], sb.add(sb.ident("a"), sb.ident("b"))),
     ];
     const expr: Expr = sb.app(sb.ident("add"), [sb.num(5), sb.bool(true)]);
 

--- a/src/infer/constraint-solver.ts
+++ b/src/infer/constraint-solver.ts
@@ -109,17 +109,20 @@ export const unifies = (c: t.Constraint, ctx: Context): t.Subst => {
     }
   }
 
-  if (subtype && isSubType(t1, t2)) {
-    return emptySubst;
+  if (
+    t.isTTuple(t1) &&
+    t.isTGen(t2) &&
+    t2.name === "Array" &&
+    t2.params.length === 1 // Array<T> should only have a single param
+  ) {
+    const constraints: t.Constraint[] = t1.types.map((type) => {
+      return { types: [type, t2.params[0]], subtype: c.subtype };
+    });
+    return unifyMany(constraints, ctx);
   }
 
-  if (t.isTTuple(t1) && t.isTGen(t2) && t2.name === "Array") {
-    if (t2.params.length === 1 && t.isTVar(t2.params[0])) {
-      const constraints: t.Constraint[] = t1.types.map((type) => {
-        return { types: [type, t2.params[0]], subtype: true };
-      });
-      return unifyMany(constraints, ctx);
-    }
+  if (subtype && isSubType(t1, t2)) {
+    return emptySubst;
   }
 
   // As long as the types haven't been frozen then this is okay
@@ -146,7 +149,7 @@ const unifyFuncs = (c: t.Constraint<t.TFun>, ctx: Context): t.Subst => {
     const t1_rest_args = t1.args.slice(t2.args.length - 1);
     const t1_varargs: t.TFun = {
       ...t1,
-      args: [...t1_regular_args, tb.ttuple(t1_rest_args, ctx)], // TODO: handle a mix of regular args and varargs
+      args: [...t1_regular_args, tb.ttuple(t1_rest_args, ctx)],
     };
     const t2_no_varargs: t.TFun = {
       ...t2,
@@ -162,8 +165,7 @@ const unifyFuncs = (c: t.Constraint<t.TFun>, ctx: Context): t.Subst => {
   // partial application
   if (t1.args.length < t2.args.length) {
     const t2_partial: t.Type = {
-      tag: "TFun",
-      id: t2.id, // is it safe to reuse `id` here?
+      ...t2,
       args: t2.args.slice(0, t1.args.length),
       ret: tb.tfun(t2.args.slice(t1.args.length), t2.ret, ctx),
     };
@@ -179,10 +181,8 @@ const unifyFuncs = (c: t.Constraint<t.TFun>, ctx: Context): t.Subst => {
     // TODO: update this once we support rest params
     if (t1.args.length > t2.args.length) {
       const t1_without_extra_args: t.Type = {
-        tag: "TFun",
-        id: t1.id, // is it safe to reuse `id` here?
+        ...t1,
         args: t1.args.slice(0, t2.args.length),
-        ret: t1.ret,
       };
       const constraints: readonly t.Constraint[] = [
         ...zipTypes(t1_without_extra_args.args, t2.args, c.subtype, true),
@@ -348,10 +348,6 @@ const isSubType = (sub: t.Type, sup: t.Type): boolean => {
 
   if (t.isTLit(sub) && t.isTLit(sup)) {
     return compareLiterals(sub.value, sup.value);
-  }
-
-  if (t.isTTuple(sub) && t.isTGen(sup) && sup.name === "Array") {
-    return sub.types.every((type) => isSubType(type, sup.params[0]));
   }
 
   // TODO: handle type aliases like Array<T> and Promise<T>

--- a/src/infer/engine.ts
+++ b/src/infer/engine.ts
@@ -38,8 +38,8 @@ export class Engine {
     return tb.tgen(name, params, this.ctx);
   }
 
-  tfun(args: readonly t.Type[], ret: t.Type) {
-    return tb.tfun(args, ret, this.ctx);
+  tfun(args: readonly t.Type[], ret: t.Type, vardiaic?: boolean) {
+    return tb.tfun(args, ret, this.ctx, vardiaic);
   }
 
   tunion(types: readonly t.Type[]) {

--- a/src/infer/infer.ts
+++ b/src/infer/infer.ts
@@ -457,8 +457,6 @@ const inferTuple = (expr: st.ETuple, ctx: Context): InferResult<tt.TTuple> => {
 
 const inferIdent = (expr: st.EIdent, ctx: Context): InferResult => {
   const type = lookupEnv(expr.name, ctx);
-  expr.name; // ?
-  type.tag; // ?
   return [type, []];
 };
 

--- a/src/infer/syntax-builders.ts
+++ b/src/infer/syntax-builders.ts
@@ -14,7 +14,7 @@ export const _if = (cond: t.Expr, th: t.Expr, el: t.Expr): t.EIf => ({
 });
 export const fix = (expr: t.Expr): t.EFix => ({ tag: "EFix", expr });
 export const lam = (
-  args: readonly string[],
+  args: readonly (t.EIdent | t.ERest)[],
   body: t.Expr,
   async?: boolean
 ): t.ELam => ({
@@ -51,6 +51,10 @@ export const mem = (
   tag: "EMem",
   object,
   property,
+});
+export const rest = (name: string): t.ERest => ({
+  tag: "ERest",
+  identifier: ident(name),
 });
 
 export const num = (value: number): t.ELit<t.LNum> => ({

--- a/src/infer/syntax-types.ts
+++ b/src/infer/syntax-types.ts
@@ -16,7 +16,7 @@ export type EApp = { tag: "EApp"; fn: Expr; args: readonly Expr[] };
 export type EAwait = { tag: "EAwait"; expr: Expr };
 export type EFix = { tag: "EFix"; expr: Expr };
 export type EIf = { tag: "EIf"; cond: Expr; th: Expr; el: Expr };
-export type ELam = { tag: "ELam"; args: readonly string[]; body: Expr; async?: boolean }; // prettier-ignore
+export type ELam = { tag: "ELam"; args: readonly (EIdent | ERest)[]; body: Expr; async?: boolean }; // prettier-ignore
 export type ELet = { tag: "ELet"; pattern: Pattern; value: Expr; body: Expr };
 export type ELit<L extends Literal = Literal> = { tag: "ELit"; value: L };
 export type EOp = { tag: "EOp"; op: Binop; left: Expr; right: Expr };
@@ -24,6 +24,7 @@ export type ERec = { tag: "ERec"; properties: readonly EProp[] };
 export type ETuple = { tag: "ETuple"; elements: readonly Expr[] };
 export type EIdent = { tag: "EIdent"; name: string };
 export type EMem = { tag: "EMem"; object: Expr; property: ELit<LNum> | ELit<LStr> | EIdent }; // prettier-ignore
+export type ERest = { tag: "ERest"; identifier: EIdent };
 
 export type Binop = "Add" | "Sub" | "Mul" | "Eql";
 export type EProp = { tag: "EProp"; name: string; value: Expr };
@@ -40,7 +41,8 @@ export type Expr =
   | ERec
   | ETuple
   | EIdent
-  | EMem;
+  | EMem
+  | ERest;
 
 /**
  * Literal types

--- a/src/infer/type-builders.ts
+++ b/src/infer/type-builders.ts
@@ -24,12 +24,14 @@ export const tgen = (
 export const tfun = (
   args: readonly t.Type[],
   ret: t.Type,
-  ctx: Context
+  ctx: Context,
+  variadic: boolean = false,
 ): t.TFun => ({
   tag: "TFun",
   id: newId(ctx),
   args,
   ret,
+  variadic,
 });
 
 export const tunion = (types: readonly t.Type[], ctx: Context): t.TUnion => ({

--- a/src/infer/type-types.ts
+++ b/src/infer/type-types.ts
@@ -165,7 +165,7 @@ export const isScheme = (t: any): t is Scheme => t.tag === "Forall";
 
 export type Constraint<T extends Type = Type> = {
   types: readonly [T, T],
-  subtype: boolean,
+  subtype: boolean, // indicates whether or not to allow types[0] to be a subtype of types[1]
 };
 
 export type Unifier = readonly [Subst, readonly Constraint[]];

--- a/src/infer/type-types.ts
+++ b/src/infer/type-types.ts
@@ -13,7 +13,7 @@ export type PrimName = "boolean" | "number" | "string" | "null" | "undefined";
 
 export type TVar = TCommon & { tag: "TVar"; name: string };
 export type TGen = TCommon & { tag: "TGen"; name: string; params: readonly Type[] }; // prettier-ignore
-export type TFun = TCommon & { tag: "TFun"; args: readonly Type[]; ret: Type }; // prettier-ignore
+export type TFun = TCommon & { tag: "TFun"; args: readonly Type[]; ret: Type; variadic?: boolean }; // prettier-ignore
 export type TUnion = TCommon & { tag: "TUnion"; types: readonly Type[] };
 export type TRec = TCommon & { tag: "TRec"; properties: readonly TProp[] };
 // TODO: need a better way model the following:
@@ -51,7 +51,16 @@ export function print(t: Type | Scheme): string {
       return t.params.length > 0 ? `${t.name}<${params}>` : t.name;
     }
     case "TFun": {
-      return `(${t.args.map(print).join(", ")}) => ${print(t.ret)}`;
+      const {variadic} = t;
+      const argCount = t.args.length;
+      const args = t.args.map((arg, index) => {
+        const isLast = index === argCount - 1;
+        if (isLast && variadic) {
+          return `...${print(arg)}`;
+        }
+        return print(arg);
+      });
+      return `(${args.join(", ")}) => ${print(t.ret)}`;
     }
     case "TUnion": {
       return t.types.map(print).join(" | ");

--- a/src/infer/util.ts
+++ b/src/infer/util.ts
@@ -214,15 +214,13 @@ export function zipTypes(
   const length = Math.min(ts1.length, ts2.length);
   const result: Constraint[] = [];
   for (let i = 0; i < length; i++) {
-    if (funcArgs && ts2[i].tag === "TFun") {
+    if (funcArgs && ts1[i].tag === "TFun" && ts2[i].tag === "TFun") {
       // Reverses the order of the types so that the TFun is first.
       // This can happen when a function is passed as a callback.
       // The callback passed should be a subtype of the expected param
       // type.  We always want to type that is a subtype to be first
-      // in the constraint tuple.
+      // when `subtype` is set to true.
       result.push({ types: [ts2[i], ts1[i]], subtype: true });
-    } else if (funcArgs && ts1[i].tag === "TFun") {
-      result.push({ types: [ts1[i], ts2[i]], subtype: true });
     } else {
       result.push({ types: [ts1[i], ts2[i]], subtype });
     }


### PR DESCRIPTION
Implements #57.

This PR makes the following changes:
- `sb.lam()` builder now requires params to be of type `EIdent` instead of `string`
- addition of `ERest` syntax type and `sb.rest()` builder
- addition of `.variadic` property on `TFun`

NOTE: I wasn't able to write any tests that exercise the `isSubtype` check.  It looks like the newly added code to unify tuples with arrays is always run instead.