### PR TITLE
simplify inferMem()

### DIFF
--- a/src/infer/__tests__/member.test.ts
+++ b/src/infer/__tests__/member.test.ts
@@ -8,13 +8,12 @@ describe("Member access", () => {
   describe("errors", () => {
     test("access on literal string fails", () => {
       const eng = new Engine();
-    addBindings(eng);
-
+      addBindings(eng);
 
       const expr = sb.mem(sb.str("foo"), sb.ident("bar"));
 
       expect(() => eng.inferExpr(expr)).toThrowErrorMatchingInlineSnapshot(
-        `"string literal doesn't contain property 'bar'"`
+        `"bar property doesn't exist on string"`
       );
     });
 

--- a/src/infer/__tests__/member.test.ts
+++ b/src/infer/__tests__/member.test.ts
@@ -14,7 +14,7 @@ describe("Member access", () => {
       const expr = sb.mem(sb.str("foo"), sb.ident("bar"));
 
       expect(() => eng.inferExpr(expr)).toThrowErrorMatchingInlineSnapshot(
-        `"String literal doesn't contain property 'bar'"`
+        `"string literal doesn't contain property 'bar'"`
       );
     });
 
@@ -25,7 +25,7 @@ describe("Member access", () => {
       const expr = sb.mem(sb.ident("foo"), sb.str("hello"));
 
       expect(() => eng.inferExpr(expr)).toThrowErrorMatchingInlineSnapshot(
-        `"property must be a variable when accessing a member on a record"`
+        `"property must be an identifier when accessing a member on a record"`
       );
     });
 
@@ -36,7 +36,7 @@ describe("Member access", () => {
       const expr = sb.mem(sb.ident("foo"), sb.ident("bar"));
 
       expect(() => eng.inferExpr(expr)).toThrowErrorMatchingInlineSnapshot(
-        `"{} doesn't contain property bar"`
+        `"Record literal doesn't contain property 'bar'"`
       );
     });
 
@@ -60,7 +60,7 @@ describe("Member access", () => {
       const expr = sb.mem(sb.ident("foo"), sb.ident("bar"));
 
       expect(() => eng.inferExpr(expr)).toThrowErrorMatchingInlineSnapshot(
-        `"number of type params in foo doesn't match those in Foo"`
+        `"Foo was given the wrong number of type params"`
       );
     });
 

--- a/src/infer/__tests__/member.test.ts
+++ b/src/infer/__tests__/member.test.ts
@@ -66,27 +66,31 @@ describe("Member access", () => {
 
     test("alias type is not a TRec", () => {
       const eng = new Engine();
+      addBindings(eng);
       eng.defScheme("Foo", scheme([], eng.tNum()));
       eng.defType("foo", eng.tgen("Foo", []));
 
       const expr = sb.mem(sb.ident("foo"), sb.ident("bar"));
 
       expect(() => eng.inferExpr(expr)).toThrowErrorMatchingInlineSnapshot(
-        `"Can't use member access on TPrim"`
+        `"bar property doesn't exist on number"`
       );
     });
 
     test("property doesn't exist on aliased TRec type", () => {
       const eng = new Engine();
+      addBindings(eng);
       eng.defScheme("Foo", scheme([], eng.trec([])));
       eng.defType("foo", eng.tgen("Foo", []));
 
       const expr = sb.mem(sb.ident("foo"), sb.ident("bar"));
 
       expect(() => eng.inferExpr(expr)).toThrowErrorMatchingInlineSnapshot(
-        `"bar property doesn't exist on {}"`
+        `"Record literal doesn't contain property 'bar'"`
       );
     });
+
+    // TODO: add more type alias tests, e.g. aliased primitives, aliased tuple
 
     test("access on TPrim stored in TVar throws", () => {
       const eng = new Engine();

--- a/src/infer/infer-mem.ts
+++ b/src/infer/infer-mem.ts
@@ -1,0 +1,198 @@
+import { Map } from "immutable";
+
+import { Context, newId } from "./context";
+import { InferResult } from "./infer-types";
+import * as tt from "./type-types";
+import * as st from "./syntax-types";
+import { zip, apply, fresh, assertUnreachable, lookupEnv } from "./util";
+import * as tb from "./type-builders";
+
+export const inferMem = (
+  infer: (expr: st.Expr, ctx: Context) => InferResult,
+  expr: st.EMem,
+  ctx: Context
+): InferResult => {
+  const { object, property } = expr;
+
+  const [obj_type, obj_cs] = infer(object, ctx);
+  const [prop_type, prop_cs] = typeOfPropertyOnType(obj_type, property, ctx);
+
+  return [prop_type, [...obj_cs, ...prop_cs]];
+};
+
+const typeOfPropertyOnType = (
+  type: tt.Type,
+  property: st.EIdent | st.ELit<st.LNum> | st.ELit<st.LStr>,
+  ctx: Context
+): InferResult => {
+  switch (type.__type) {
+    case "TVar": {
+      const tobj = fresh(ctx);
+      const tMem1 = tb.tmem(tobj, unwrapProperty(property), ctx);
+      const tMem2 = tb.tmem(type, unwrapProperty(property), ctx);
+
+      // This is sufficient since inferTMem() will unify `tobj` with `type`.
+      return [tMem2, [{ types: [tMem1, tMem2], subtype: false }]];
+    }
+    case "TRec": {
+      if (!isIdent(property)) {
+        throw new Error(
+          "property must be an identifier when accessing a member on a record"
+        );
+      }
+
+      const tobj = fresh(ctx);
+      const tMem1 = tb.tmem(tobj, unwrapProperty(property), ctx);
+      const tMem2 = tb.tmem(type, unwrapProperty(property), ctx);
+      const prop = type.properties.find((prop) => property.name === prop.name);
+
+      if (!prop) {
+        throw new Error(
+          `Record literal doesn't contain property '${property.name}'`
+        );
+      }
+
+      // This is sufficient since infer() will unify `tobj` with `type`.
+      return [prop.type, [{ types: [tMem1, tMem2], subtype: false }]];
+    }
+    case "TTuple": {
+      if (!isNumLit(property)) {
+        throw new Error(
+          "property must be a number when accessing an index on a tuple"
+        );
+      }
+
+      const tobj = fresh(ctx);
+      const tMem1 = tb.tmem(tobj, unwrapProperty(property), ctx);
+      const tMem2 = tb.tmem(type, unwrapProperty(property), ctx);
+
+      if (property.value.value >= type.types.length) {
+        throw new Error("index is greater than the size of the tuple");
+      }
+
+      const elemType = type.types[property.value.value];
+      return [elemType, [{ types: [tMem1, tMem2], subtype: false }]];
+    }
+    case "TPrim":
+    case "TLit": {
+      const primName = getPrimName(type);
+      const newType = lookupEnv(primName, ctx);
+
+      // TODO: write some tests where like "hello"[0] to see what happens.
+      try {
+        return typeOfPropertyOnType(newType, property, ctx);
+      } catch (e) {
+        if (tt.isTPrim(type)) {
+          throw new Error(
+            `${unwrapProperty(property)} property doesn't exist on ${primName}`
+          );
+        } else {
+          throw new Error(
+            `${primName} literal doesn't contain property '${unwrapProperty(
+              property
+            )}'`
+          );
+        }
+      }
+    }
+    case "TGen": {
+      const aliasedScheme = ctx.env.get(type.name);
+      if (!aliasedScheme) {
+        throw new Error(`No type named ${type.name} in environment`);
+      }
+
+      if (aliasedScheme.qualifiers.length !== type.params.length) {
+        throw new Error(
+          `${type.name} was given the wrong number of type params`
+        );
+      }
+
+      // If we're trying to access an element on an Array it's possible that
+      // an element doesn't exist at the desired index.  To reflect this, we
+      // extend the type to be `T | undefined`.
+      if (
+        type.name === "Array" &&
+        property.__type === "ELit" &&
+        property.value.__type === "LNum"
+      ) {
+        // TODO: flatten union types if the Array contains a union to begin with.
+        const resultType = tb.tunion(
+          [type.params[0], tb.tlit({ __type: "LUndefined" }, ctx)],
+          ctx
+        );
+        return [resultType, []];
+      }
+
+      // Creates a bunch of substitutions from qualifier ids to type params
+      const subs1: tt.Subst = Map(
+        zip(aliasedScheme.qualifiers, type.params).map(([q, param]) => {
+          // We need a fresh copy of the params so we don't accidentally end
+          // sharing state between the type params.
+          const freshParam = { ...param, id: newId(ctx) };
+          return [q.id, freshParam];
+        })
+      );
+      // Applies the substitutions to get a type matches the type alias we looked up
+      const aliasedType = apply(subs1, aliasedScheme.type);
+
+      return typeOfPropertyOnType(aliasedType, property, ctx);
+    }
+    case "TFun": {
+      // This is to handle things like .toString() on functions.  Not sure if
+      // this will help with callables or not.
+      throw new Error("TODO: handle member access on function");
+    }
+    case "TMem": {
+      // It looks like we're handling this already, look at constraint-solver
+      // for clues.  It would be nice to have member access on all types handled
+      // in the same place.
+      throw new Error("TODO: handle member access on a member access");
+    }
+    case "TUnion": {
+      // Get the type of the property on each member of the union.  If
+      // the property doesn't exist then the type should be undefined.
+      // We should do the same for TRec.  We can track the error will
+      // still allowing type inference to continue.
+      throw new Error("TODO: handle member access on a union");
+    }
+    default:
+      assertUnreachable(type);
+  }
+};
+
+const unwrapProperty = (
+  property: st.EIdent | st.ELit<st.LNum> | st.ELit<st.LStr>
+): number | string => {
+  if (isIdent(property)) {
+    return property.name;
+  } else if (isStrLit(property)) {
+    return property.value.value;
+  } else {
+    return property.value.value;
+  }
+};
+
+const isNumLit = (e: st.Expr): e is st.ELit<st.LNum> =>
+  e.__type === "ELit" && e.value.__type === "LNum";
+const isStrLit = (e: st.Expr): e is st.ELit<st.LStr> =>
+  e.__type === "ELit" && e.value.__type === "LStr";
+const isIdent = (e: st.Expr): e is st.EIdent => e.__type === "EIdent";
+
+const getPrimName = (type: tt.TPrim | tt.TLit): tt.PrimName => {
+  if (tt.isTPrim(type)) {
+    return type.name;
+  } else {
+    switch (type.value.__type) {
+      case "LNum":
+        return "number";
+      case "LStr":
+        return "string";
+      case "LBool":
+        return "boolean";
+      case "LNull":
+        return "null";
+      case "LUndefined":
+        return "undefined";
+    }
+  }
+};

--- a/src/infer/infer-mem.ts
+++ b/src/infer/infer-mem.ts
@@ -82,17 +82,9 @@ const typeOfPropertyOnType = (
       try {
         return typeOfPropertyOnType(newType, property, ctx);
       } catch (e) {
-        if (tt.isTPrim(type)) {
-          throw new Error(
-            `${unwrapProperty(property)} property doesn't exist on ${primName}`
-          );
-        } else {
-          throw new Error(
-            `${primName} literal doesn't contain property '${unwrapProperty(
-              property
-            )}'`
-          );
-        }
+        throw new Error(
+          `${unwrapProperty(property)} property doesn't exist on ${primName}`
+        );
       }
     }
     case "TGen": {

--- a/src/infer/infer-types.ts
+++ b/src/infer/infer-types.ts
@@ -1,0 +1,6 @@
+import * as tt from "./type-types";
+
+export type InferResult<T extends tt.Type = tt.Type> = readonly [
+  T,
+  readonly tt.Constraint[]
+];

--- a/src/infer/infer.ts
+++ b/src/infer/infer.ts
@@ -1,13 +1,23 @@
 import { Map } from "immutable";
 
-import { Env, Context, State, newId } from "./context";
-import { UnboundVariable } from "./errors";
+import { Env, Context, State } from "./context";
+import { InferResult } from "./infer-types";
 import * as tt from "./type-types";
 import * as st from "./syntax-types";
-import { zip, apply, ftv, assertUnreachable } from "./util";
 import { runSolve } from "./constraint-solver";
 import * as tb from "./type-builders";
 import { getOperationType } from "./graphql";
+import { inferMem } from "./infer-mem";
+import {
+  zip,
+  apply,
+  ftv,
+  assertUnreachable,
+  fresh,
+  freshTCon,
+  letterFromIndex,
+  lookupEnv,
+} from "./util";
 
 const emptyEnv: Env = Map();
 
@@ -142,58 +152,9 @@ const normalize = (sc: tt.Scheme): tt.Scheme => {
   return tt.scheme(values, normType(body));
 };
 
-// Lookup type in the environment
-const lookupEnv = (name: string, ctx: Context): tt.Type => {
-  const value = ctx.env.get(name);
-  if (!value) {
-    // TODO: keep track of all unbound variables in a decl
-    // we can return `unknown` as the type so that unifcation
-    // can continue.
-    throw new UnboundVariable(name);
-  }
-  return instantiate(value, ctx);
-};
-
-const letterFromIndex = (index: number): string =>
-  String.fromCharCode(97 + index);
-
-// TODO: defer naming until print time
-export const fresh = (ctx: Context): tt.TVar => {
-  const id = newId(ctx);
-  return {
-    __type: "TVar",
-    id: id,
-    name: letterFromIndex(id),
-  };
-};
-
-export const freshTCon = (
-  ctx: Context,
-  name: string,
-  params: tt.Type[] = []
-): tt.TGen => {
-  return tb.tgen(name, params, ctx);
-};
-
-const instantiate = (sc: tt.Scheme, ctx: Context): tt.Type => {
-  const freshQualifiers = sc.qualifiers.map(() => fresh(ctx));
-  const subs = Map(
-    zip(
-      sc.qualifiers.map((qual) => qual.id),
-      freshQualifiers
-    )
-  );
-  return apply(subs, sc.type);
-};
-
 const generalize = (env: Env, type: tt.Type): tt.Scheme => {
   return tt.scheme(ftv(type).subtract(ftv(env)).toArray(), type);
 };
-
-type InferResult<T extends tt.Type = tt.Type> = readonly [
-  T,
-  readonly tt.Constraint[]
-];
 
 const infer = (expr: st.Expr, ctx: Context): InferResult => {
   // prettier-ignore
@@ -209,7 +170,7 @@ const infer = (expr: st.Expr, ctx: Context): InferResult => {
     case "EAwait":   return inferAwait  (expr, ctx);
     case "ERec":     return inferRec    (expr, ctx);
     case "ETuple":   return inferTuple  (expr, ctx);
-    case "EMem":     return inferMem    (expr, ctx);
+    case "EMem":     return inferMem    (infer, expr, ctx);
     case "ERest":    return inferRest   (expr, ctx);
     case "ETagTemp": return inferTagTemp(expr, ctx);
     default: assertUnreachable(expr);
@@ -460,183 +421,6 @@ const inferTuple = (expr: st.ETuple, ctx: Context): InferResult<tt.TTuple> => {
 const inferIdent = (expr: st.EIdent, ctx: Context): InferResult => {
   const type = lookupEnv(expr.name, ctx);
   return [type, []];
-};
-
-const unwrapProperty = (property: st.Expr): number | string => {
-  if (property.__type === "EIdent") {
-    return property.name;
-  } else if (property.__type === "ELit" && property.value.__type === "LNum") {
-    return property.value.value;
-  } else {
-    throw new Error("Not a valid property");
-  }
-};
-
-const inferObjectProperty = (
-  type: tt.TRec,
-  cs: readonly tt.Constraint[],
-  property: st.EIdent,
-  ctx: Context
-): InferResult => {
-  const tobj = fresh(ctx);
-  const tMem1 = tb.tmem(tobj, unwrapProperty(property), ctx);
-  const tMem2 = tb.tmem(type, unwrapProperty(property), ctx);
-  const prop = type.properties.find((prop) => property.name === prop.name);
-
-  if (!prop) {
-    throw new Error(
-      `Record literal doesn't contain property '${property.name}'`
-    );
-  }
-
-  // This is sufficient since infer() will unify `tobj` with `type`.
-  return [prop.type, [...cs, { types: [tMem1, tMem2], subtype: false }]];
-};
-
-const isNumLit = (e: st.Expr): e is st.ELit<st.LNum> =>
-  e.__type === "ELit" && e.value.__type === "LNum";
-const isIdent = (e: st.Expr): e is st.EIdent => e.__type === "EIdent";
-
-const getPrimName = (type: tt.TPrim | tt.TLit): tt.PrimName => {
-  if (tt.isTPrim(type)) {
-    return type.name;
-  } else {
-    switch (type.value.__type) {
-      case "LNum": return "number";
-      case "LStr": return "string";
-      case "LBool": return "boolean";
-      case "LNull": return "null";
-      case "LUndefined": return "undefined";
-    }
-  }
-}
-
-const inferMem = (expr: st.EMem, ctx: Context): InferResult => {
-  // TODO: handle nested property access, e.g. foo.bar.baz.
-  const { object, property } = expr;
-
-  const [type, cs] = infer(object, ctx);
-
-  if (tt.isTRec(type)) {
-    if (!isIdent(property)) {
-      throw new Error(
-        "property must be an identifier when accessing a member on a record"
-      );
-    }
-    return inferObjectProperty(type, cs, property, ctx);
-  } else if (tt.isTTuple(type)) {
-    if (!isNumLit(property)) {
-      throw new Error(
-        "property must be a number when accessing an index on a tuple"
-      );
-    }
-
-    const tobj = fresh(ctx);
-    const tMem1 = tb.tmem(tobj, unwrapProperty(property), ctx);
-    const tMem2 = tb.tmem(type, unwrapProperty(property), ctx);
-
-    if (property.value.value >= type.types.length) {
-      throw new Error("index is greater than the size of the tuple");
-    }
-
-    const elemType = type.types[property.value.value];
-    return [elemType, [...cs, { types: [tMem1, tMem2], subtype: false }]];
-  } else if (tt.isTPrim(type) || tt.isTLit(type)) {
-    const primName = getPrimName(type);
-    const newType = lookupEnv(primName, ctx);
-    // TODO: extract this if-elseif-else block of logic into a separate
-    // helper function so that it can be recursive
-    if (tt.isTRec(newType) && property.__type === "EIdent") {
-      try {
-        return inferObjectProperty(newType, [], property, ctx);
-      } catch (e) {
-        if (tt.isTPrim(type)) {
-          throw new Error(
-            `${property.name} property doesn't exist on ${primName}`
-          );
-        } else {
-          throw new Error(
-            `${primName} literal doesn't contain property '${property.name}'`
-          );
-        }
-      }
-    } else {
-      throw new Error("object must be a variable when accessing a member");
-    }
-  } else if (tt.isTVar(type)) {
-    const tobj = fresh(ctx);
-    const tMem1 = tb.tmem(tobj, unwrapProperty(property), ctx);
-    const tMem2 = tb.tmem(type, unwrapProperty(property), ctx);
-
-    // This is sufficient since inferTMem() will unify `tobj` with `type`.
-    return [tMem2, [...cs, { types: [tMem1, tMem2], subtype: false }]];
-  } else if (tt.isTGen(type)) {
-    const aliasedScheme = ctx.env.get(type.name);
-    if (!aliasedScheme) {
-      throw new Error(`No type named ${type.name} in environment`);
-    }
-  
-    if (aliasedScheme.qualifiers.length !== type.params.length) {
-      throw new Error(
-        `${type.name} was given the wrong number of type params`
-      );
-    }
-  
-    // Creates a bunch of substitutions from qualifier ids to type params
-    const subs1: tt.Subst = Map(
-      zip(aliasedScheme.qualifiers, type.params).map(([q, param]) => {
-        // We need a fresh copy of the params so we don't accidentally end
-        // sharing state between the type params.
-        const freshParam = { ...param, id: newId(ctx) };
-        return [q.id, freshParam];
-      })
-    );
-    // Applies the substitutions to get a type matches the type alias we looked up
-    const aliasedType = apply(subs1, aliasedScheme.type);
-  
-    if (
-      type.name === "Array" &&
-      property.__type === "ELit" &&
-      property.value.__type === "LNum"
-    ) {
-      const resultType = tb.tunion(
-        [type.params[0], tb.tlit({ __type: "LUndefined" }, ctx)],
-        ctx
-      );
-      return [resultType, cs];
-    }
-  
-    // TODO: handle aliased tuple types (not common so we can punt on it for now)
-    if (!tt.isTRec(aliasedType)) {
-      throw new Error(`Can't use member access on ${aliasedType.__type}`);
-    }
-  
-    if (property.__type !== "EIdent") {
-      throw new Error(
-        "property must be a variable when accessing a member on a record"
-      );
-    }
-  
-    const prop = aliasedType.properties.find(
-      (prop) => prop.name === property.name
-    );
-  
-    if (!prop) {
-      throw new Error(
-        `${property.name} property doesn't exist on ${tt.print(aliasedType)}`
-      );
-    }
-  
-    // Replaces all free variables with fresh ones
-    const subs2: tt.Subst = Map(
-      [...ftv(prop.type)].map((v) => [v.id, fresh(ctx)])
-    );
-    const resultType = apply(subs2, prop.type);
-  
-    return [resultType, cs];
-  } else {
-    throw new Error("Didn't expect to get here");
-  }
 };
 
 const inferRest = (expr: st.ERest, ctx: Context): InferResult => {


### PR DESCRIPTION
- extracted duplicate logic into `inferObjectProperty`
- added `isFoo` helpers for some `Expr` nodes
- call `[type, cs] = infer(object, ctx)` first and then customize behaviour based on the returned `type`